### PR TITLE
[fix] 홈 화면의 아이템 리스트에서 장바구니 버튼 활성화 상태가 업데이트되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 import kotlinx.android.parcel.Parcelize
 
 @Parcelize
-data class WishItem (
+data class WishItem(
     @SerializedName("folder_id")
     val folderId: Long? = null,
     @SerializedName("folder_name")
@@ -19,7 +19,7 @@ data class WishItem (
     @SerializedName("item_price")
     val price: Int? = null,
     @SerializedName("item_url")
-    val url: String?= null,
+    val url: String? = null,
     @SerializedName("item_memo")
     val memo: String? = null,
     @SerializedName("create_at")
@@ -29,5 +29,5 @@ data class WishItem (
     @SerializedName("item_notification_date")
     val notiDate: String? = null,
     @SerializedName("cart_item_id")
-    val cartId: Long? = null,
-): Parcelable
+    var cartId: Long? = null, // TODO isAddedCart: Boolean 으로 변경 논의 필요
+) : Parcelable

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -12,12 +12,11 @@ class WishListAdapter(
     private val context: Context
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val dataSet = arrayListOf<WishItem>()
-    private lateinit var selectedCartButtons: Array<Boolean>
     private lateinit var listener: OnItemClickListener
 
     interface OnItemClickListener {
         fun onItemClick(item: WishItem)
-        fun onCartBtnClick(itemId: Long, isAdded: Boolean)
+        fun onCartBtnClick(position: Int, item: WishItem, isSelected: Boolean)
     }
 
     fun setOnItemClickListener(listener: OnItemClickListener) {
@@ -28,27 +27,17 @@ class WishListAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(position: Int) {
             val item = dataSet[position]
-
             with(binding) {
                 this.item = item
                 Glide.with(context).load(item.image).into(itemImage)
-
-                if (item.cartId == null) {
-                    binding.cart.isSelected = false
-                    selectedCartButtons[position] = false
-                } else {
-                    binding.cart.isSelected = true
-                    selectedCartButtons[position] = true
-                }
+                binding.cart.isSelected = item.cartId != null
 
                 container.setOnClickListener {
                     listener.onItemClick(item)
                 }
 
                 cart.setOnClickListener {
-                    it.isSelected = !it.isSelected
-                    selectedCartButtons[position] = !selectedCartButtons[position]
-                    listener.onCartBtnClick(item.id ?: return@setOnClickListener, selectedCartButtons[position])
+                    listener.onCartBtnClick(position, item, binding.cart.isSelected)
                 }
             }
         }
@@ -72,10 +61,15 @@ class WishListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+    /** 아이템 정보(타이틀 및 가격 등)수정, cart 포함 여부 수정에 사용 */
+    fun updateData(position: Int, wishItem: WishItem) {
+        dataSet[position] = wishItem
+        notifyItemChanged(position)
+    }
+
     fun setData(items: List<WishItem>) {
         dataSet.clear()
         dataSet.addAll(items)
-        selectedCartButtons = Array(dataSet.size) { false }
         notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
@@ -24,7 +24,7 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
 
         initializeView()
@@ -35,7 +35,7 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
     }
 
     private fun initializeView() {
-        adapter = WishListAdapter(requireContext())
+        adapter = viewModel.getWishListAdapter()
         adapter.setOnItemClickListener(this)
         binding.wishList.adapter = adapter
         binding.wishList.layoutManager = GridLayoutManager(requireContext(), 2)
@@ -66,11 +66,11 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
         )
     }
 
-    override fun onCartBtnClick(itemId: Long, isSelected: Boolean) {
-        if (isSelected) {
-            viewModel.addToCart(itemId)
+    override fun onCartBtnClick(position: Int, item: WishItem, isSelected: Boolean) {
+        if (!isSelected) {
+            viewModel.addToCart(position, item)
         } else {
-            viewModel.removeToCart(itemId)
+            viewModel.removeToCart(position, item)
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishViewModel.kt
@@ -1,5 +1,6 @@
 package com.hyeeyoung.wishboard.viewmodel
 
+import android.app.Application
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -9,17 +10,22 @@ import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.repository.cart.CartRepository
 import com.hyeeyoung.wishboard.repository.wish.WishRepository
 import com.hyeeyoung.wishboard.util.prefs
+import com.hyeeyoung.wishboard.view.wish.list.adapters.WishListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WishViewModel @Inject constructor( // TODO WishListViewModel 및 WishItemViewModel로 구분하여 정리 필요
+class WishViewModel @Inject constructor(
+    // TODO WishListViewModel로 이름 변경
+    private val application: Application,
     private val wishRepository: WishRepository,
     private val cartRepository: CartRepository,
 ) : ViewModel() {
-    private var wishList = MutableLiveData<List<WishItem>>(arrayListOf())
+    private var wishList = MutableLiveData<MutableList<WishItem>>(mutableListOf())
     private var wishItem = MutableLiveData<WishItem>()
+    private val wishListAdapter = WishListAdapter(application)
+
     private val token = prefs?.getUserToken()
 
     init {
@@ -31,30 +37,43 @@ class WishViewModel @Inject constructor( // TODO WishListViewModel 및 WishItemV
         Log.d(TAG, "token: $token")
         viewModelScope.launch {
             val items = wishRepository.fetchWishList(token)
-            wishList.postValue(items)
+            wishList.postValue(items?.toMutableList())
         }
     }
 
-    fun addToCart(itemId: Long) {
+    fun addToCart(position: Int, item: WishItem) {
         if (token == null) return
         viewModelScope.launch {
-            cartRepository.addToCart(token, itemId)
+            val isSuccessful = cartRepository.addToCart(token, item.id ?: return@launch)
+            if (!isSuccessful) return@launch // TODO 네트워크 연결 실패, 그 외 나머지 예외 처리 -> 스낵바 띄우기
+            item.also { wishItem ->
+                wishItem.cartId = wishItem.id
+                wishList.value?.set(position, wishItem)
+                wishListAdapter.updateData(position, wishItem)
+            }
         }
     }
 
-    fun removeToCart(itemId: Long) {
+    fun removeToCart(position: Int, item: WishItem) {
         if (token == null) return
         viewModelScope.launch {
-            cartRepository.removeToCart(token, itemId)
+            val isSuccessful = cartRepository.removeToCart(token, item.id ?: return@launch)
+            if (!isSuccessful) return@launch // TODO 예외 처리 필요, 스낵바 띄우기
+            item.also { wishItem ->
+                wishItem.cartId = null // TODO 서버에서 cartId(-> isAddedCart) 값의 null 여부에 따라 0, 1(Boolean)로 수정할 수 있는지 논의 필요
+                wishList.value?.set(position, wishItem)
+                wishListAdapter.updateData(position, wishItem)
+            }
         }
     }
 
-    fun setWishItem(wishItem: WishItem) {
+    fun setWishItem(wishItem: WishItem) { // TODO WishItemViewModel로 이동
         this.wishItem.value = wishItem
     }
 
-    fun getWishList(): LiveData<List<WishItem>?> = wishList
+    fun getWishList(): LiveData<MutableList<WishItem>?> = wishList
     fun getWishItem(): LiveData<WishItem> = wishItem
+    fun getWishListAdapter(): WishListAdapter = wishListAdapter
 
     companion object {
         private val TAG = "WishViewModel"


### PR DESCRIPTION
#### 문제 : 홈화면 > 아이템 > 장바구니 버튼 활성화한 후 다른 화면으로 전환 -> 해당화면으로 돌아왔을 때 장바구니의 버튼이 다시 비활성화 되어있음
#### 원인 : `WishViewModel > wishList`, `WishListAdapter > dataSet` 갱신 처리 부재
---
#### 해결 : 
- `WishItem.kt` > `val cartId` -> `var cartId`로 변경
     - cartId 속성을 변경할 때 단순히 plus(), minus(), times()등 내장함수를 사용하여 값을 바꿀 수 없고, 전달받은 명확한 값으로 reassignment 해주어야하기 때문에 var로 바꿈
     - isAddedCart: Boolean 으로 변경 논의 필요 -> 세부내용은 노션 논의사항에 적어두었고, 백엔드는 혜정이가 수정ing..

- `WishViewModel.kt` > wishList 갱신
     - ` wishList = MutableLiveData<List<WishItem>>(arrayListOf())` 에서 `wishList = MutableLiveData<MutableList<WishItem>>(mutableListOf())` 로 변경
     - `wishList.value?.set(position, wishItem)`으로 item의 변경사항을 반영하기 위함
     - MutableList : 변경가능한 List(Immutable)
          - 그럼 ArrayList와의 차이는? 제가 궁금해서 찾아봄. 사용 상 차이는 없다고 함 ▶️ [참고](https://stackoverflow.com/questions/43114367/difference-between-arrayliststring-and-mutablelistofstring-in-kotlin)

- `WishListAdapter.kt` > dataSet 갱신
     - `fun onCartBtnClick()` 파라미터 수정 `(itemId: Long, isAdded: Boolean)` -> `(position: Int, item: WishItem, isSelected: Boolean)`
     -  position 추가, itemId만 전달 -> item 정보 자체를 전달
     - 장바구니 버튼 클릭 시 어뎁터의 dataSet을 갱신하기위해 아래 함수를 호출하려면 position과 item 정보 필요
```kotlin
    fun updateData(position: Int, wishItem: WishItem) {
        dataSet[position] = wishItem
        notifyItemChanged(position)
    }
```


