### PR TITLE
[mod] WishItem에서 cartId를 cartState로 프로퍼티 이름 변경 및 홈에서 cart 버튼 클릭 시 car…

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/cart/CartStateType.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/cart/CartStateType.kt
@@ -1,0 +1,6 @@
+package com.hyeeyoung.wishboard.model.cart
+
+enum class CartStateType(val numValue: Int) {
+    IN_CART(1),
+    NOT_IN_CART(0)
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
@@ -28,6 +28,7 @@ data class WishItem(
     val notiType: String? = null,
     @SerializedName("item_notification_date")
     val notiDate: String? = null,
-    @SerializedName("cart_item_id")
-    var cartId: Long? = null, // TODO isAddedCart: Boolean 으로 변경 논의 필요
+    /** cartState(1) : 장바구니에 존재, cartState(0) : 장바구니에 존재 X*/
+    @SerializedName("cart_state")
+    var cartState: Int? = null,
 ) : Parcelable

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.databinding.ItemWishBinding
+import com.hyeeyoung.wishboard.model.cart.CartStateType
 import com.hyeeyoung.wishboard.model.wish.WishItem
 
 class WishListAdapter(
@@ -16,7 +17,7 @@ class WishListAdapter(
 
     interface OnItemClickListener {
         fun onItemClick(item: WishItem)
-        fun onCartBtnClick(position: Int, item: WishItem, isSelected: Boolean)
+        fun onCartBtnClick(position: Int, item: WishItem)
     }
 
     fun setOnItemClickListener(listener: OnItemClickListener) {
@@ -30,14 +31,14 @@ class WishListAdapter(
             with(binding) {
                 this.item = item
                 Glide.with(context).load(item.image).into(itemImage)
-                binding.cart.isSelected = item.cartId != null
+                binding.cart.isSelected = item.cartState == CartStateType.IN_CART.numValue
 
                 container.setOnClickListener {
                     listener.onItemClick(item)
                 }
 
                 cart.setOnClickListener {
-                    listener.onCartBtnClick(position, item, binding.cart.isSelected)
+                    listener.onCartBtnClick(position, item)
                 }
             }
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
@@ -51,6 +51,7 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
         }
     }
 
+    // TODO addObservers() 삭제 -> viewModel에서 adapter.setData() 호출
     private fun addObservers() {
         viewModel.getWishList().observe(viewLifecycleOwner) {
             it?.let {
@@ -66,12 +67,8 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
         )
     }
 
-    override fun onCartBtnClick(position: Int, item: WishItem, isSelected: Boolean) {
-        if (!isSelected) {
-            viewModel.addToCart(position, item)
-        } else {
-            viewModel.removeToCart(position, item)
-        }
+    override fun onCartBtnClick(position: Int, item: WishItem) {
+        viewModel.toggleCartState(position, item)
     }
 
     companion object {


### PR DESCRIPTION
**`WishItem.kt` >  cartId의 프로퍼티명과 데이터 타입 변경** 
- 프로퍼티명 : `cartState` -> `cartState`
- 데이터타입 : `Long` -> `Int` 
- 이 부분은 생략해도 됨 
     - 데이터 타입을 `CartStateType`로 지정할까 고민했는데, 이 경우 DB에 값 저장할 때 `"IN_THE_CART"`, `"IN_CART"`와 같이 `string`타입으로 저장해야함. 현재 DB에서의 `cart_state`의 타입이 `tinyInt`이므로 string값 지정 불가함. 또한 `cart_state`타입을 `varchar`로 바꾼다 해도 안드에서 `cart_state`값을 fetch 할 때 `CartStateType`타입으로 변환 과정을 거쳐야함
          - `CartStateType.valueOf("IN_THE_CART")`와 같이 `EnumClass.valueOf()`를 사용하여 인자로 넘긴 `string`값과 일치하는 `enum constant` 반환

---
**`CartStateType.kt` enum class 추가**
- WishItem > cartState값 지정 시 사용
- 장바구니에 존재함 : IN_CART(1), 장바구니에 존재하지 않음 : NOT_IN_CART(0)
- `numValue`의 경우 cartState의 데이터 타입 Int에 맞추어 값을 부여
- ex) CartStateType.IN_THE_CART.numvalue : 1

---

**`WishListAdapter.kt` 정리 및 cartState 적용**
- `onCartBtnClick(position: Int, item: WishItem, isSelected: Boolean)`에서 필요없는 `isSelected` 삭제
     - 필요없는 이유 : item.cartState를 isSelected 대신 사용하려함
- cart 버튼 활성화 처리 시 `item.cartState` 값 사용

---

**`HomeFragment.kt 정리`**
- 기존에 `onCartBtnClick()`에서 인자 `isSelected`에 따라 addToCart(), removeToCart() 호출 -> `isSelected` 삭제됨에 따라 `toggleCartState()` 호출

---

**`WishViewModel`정리 및 cartState 적용** 
- `addToCart()`, `remoteToCart()`를 `toggleCartState()`로 합침