### PR TITLE
[feat] 아이템 삭제 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -33,6 +33,13 @@ interface RemoteService {
         @Body wishItem: WishItem
     ): Response<RequestResult>
 
+    @FormUrlEncoded
+    @HTTP(method = "DELETE", path = "item", hasBody = true)
+    suspend fun deleteWishItem(
+        @Header("Authorization") token: String,
+        @Field("item_id") itemId: Long
+    ): Response<RequestResult>
+
     // 장바구니
     @GET("cart")
     suspend fun fetchCart(@Header("Authorization") token: String): Response<List<CartItem>>?

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepository.kt
@@ -5,4 +5,5 @@ import com.hyeeyoung.wishboard.model.wish.WishItem
 interface WishRepository {
     suspend fun fetchWishList(token: String): List<WishItem>?
     suspend fun uploadWishItem(token: String, wishItem: WishItem): Boolean
+    suspend fun deleteWishItem(token: String, itemId: Long): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepositoryImpl.kt
@@ -29,6 +29,17 @@ class WishRepositoryImpl : WishRepository {
         return response.isSuccessful
     }
 
+    override suspend fun deleteWishItem(token: String, itemId: Long): Boolean {
+        val response = api.deleteWishItem(token, itemId)
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "아이템 삭제 성공")
+        } else {
+            Log.e(TAG, "아이템 삭제 실패: ${response.code()}")
+        }
+        return response.isSuccessful
+    }
+
     companion object {
         private const val TAG = "WishRepositoryImpl"
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
@@ -6,8 +6,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
+import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishItemDetailBinding
@@ -19,6 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 class WishItemDetailFragment : Fragment() {
     private lateinit var binding: FragmentWishItemDetailBinding
     private val viewModel: WishItemViewModel by hiltNavGraphViewModels(R.id.wish_item_nav_graph)
+    private var position: Int? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -30,6 +34,8 @@ class WishItemDetailFragment : Fragment() {
 
         arguments?.let {
             val wishItem = it[ARG_WISH_ITEM] as? WishItem
+            position = it[ARG_WISH_ITEM_POSITION] as? Int
+
             if (wishItem != null) {
                 viewModel.setWishItem(wishItem)
             }
@@ -48,10 +54,33 @@ class WishItemDetailFragment : Fragment() {
             }
             Glide.with(requireContext()).load(wishItem.image).into(binding.itemImage)
         }
+
+        viewModel.getIsCompleteDeletion().observe(viewLifecycleOwner) { isComplete ->
+            if (isComplete == true) {
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.wish_item_deletion_toast_text),
+                    Toast.LENGTH_SHORT
+                ).show()
+
+                moveToMain()
+            }
+        }
+    }
+
+    private fun moveToMain() {
+        val navController = findNavController()
+        navController.previousBackStackEntry?.savedStateHandle?.set(ARG_WISH_ITEM_INFO, bundleOf(
+            ARG_WISH_ITEM to viewModel.getWishItem().value,
+            ARG_WISH_ITEM_POSITION to position
+        ))
+        navController.popBackStack()
     }
 
     companion object {
         private const val TAG = "WishItemDetailFragment"
         private const val ARG_WISH_ITEM = "wishItem"
+        private const val ARG_WISH_ITEM_POSITION = "position"
+        private const val ARG_WISH_ITEM_INFO = "wishItemInfo"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -16,7 +16,7 @@ class WishListAdapter(
     private lateinit var listener: OnItemClickListener
 
     interface OnItemClickListener {
-        fun onItemClick(item: WishItem)
+        fun onItemClick(position: Int, item: WishItem)
         fun onCartBtnClick(position: Int, item: WishItem)
     }
 
@@ -34,7 +34,7 @@ class WishListAdapter(
                 binding.cart.isSelected = item.cartState == CartStateType.IN_CART.numValue
 
                 container.setOnClickListener {
-                    listener.onItemClick(item)
+                    listener.onItemClick(position, item)
                 }
 
                 cart.setOnClickListener {
@@ -66,6 +66,11 @@ class WishListAdapter(
     fun updateData(position: Int, wishItem: WishItem) {
         dataSet[position] = wishItem
         notifyItemChanged(position)
+    }
+
+    fun deleteData(position: Int, wishItem: WishItem) {
+        dataSet.remove(wishItem)
+        notifyItemRemoved(position)
     }
 
     fun setData(items: List<WishItem>) {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
@@ -13,6 +13,7 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentHomeBinding
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
+import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.wish.list.adapters.WishListAdapter
 import com.hyeeyoung.wishboard.viewmodel.WishListViewModel
 
@@ -58,12 +59,27 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
                 adapter.setData(it)
             }
         }
+
+        // 상세조회에서 아이템 삭제 완료 후 홈으로 복귀했을 때 해당 아이템 정보를 전달받고, ui를 업데이트
+        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Bundle>(
+            ARG_WISH_ITEM_INFO
+        )?.observe(viewLifecycleOwner) {
+            safeLet(
+                it[ARG_WISH_ITEM_POSITION] as? Int,
+                it[ARG_WISH_ITEM] as? WishItem
+            ) { position, withITem ->
+                viewModel.deleteWishItem(position, withITem)
+            }
+        }
     }
 
-    override fun onItemClick(item: WishItem) {
+    override fun onItemClick(position: Int, item: WishItem) {
         findNavController().navigateSafe(
             R.id.action_home_to_wish_item_detail,
-            bundleOf(ARG_WISH_ITEM to item)
+            bundleOf(
+                ARG_WISH_ITEM_POSITION to position,
+                ARG_WISH_ITEM to item,
+            )
         )
     }
 
@@ -73,6 +89,8 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
 
     companion object {
         private const val TAG = "HomeFragment"
-        const val ARG_WISH_ITEM = "wishItem"
+        private const val ARG_WISH_ITEM = "wishItem"
+        private const val ARG_WISH_ITEM_POSITION = "position"
+        private const val ARG_WISH_ITEM_INFO = "wishItemInfo"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
@@ -3,19 +3,38 @@ package com.hyeeyoung.wishboard.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.hyeeyoung.wishboard.model.wish.WishItem
+import com.hyeeyoung.wishboard.repository.wish.WishRepository
+import com.hyeeyoung.wishboard.util.prefs
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class WishItemViewModel @Inject constructor() : ViewModel() {
+class WishItemViewModel @Inject constructor(
+    private val wishRepository: WishRepository,
+) : ViewModel() {
+    private val token = prefs?.getUserToken()
+
     private var wishItem = MutableLiveData<WishItem>()
+    private var isCompleteDeletion = MutableLiveData<Boolean>()
+
+    fun deleteWishItem() {
+        if (token == null) return
+        val itemId = wishItem.value?.id ?: return
+
+        viewModelScope.launch {
+            isCompleteDeletion.value = wishRepository.deleteWishItem(token, itemId)
+        }
+    }
 
     fun setWishItem(wishItem: WishItem) {
         this.wishItem.value = wishItem
     }
 
     fun getWishItem(): LiveData<WishItem> = wishItem
+    fun getIsCompleteDeletion(): LiveData<Boolean> = isCompleteDeletion
 
     companion object {
         private const val TAG = "WishItemViewModel"

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishListViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishListViewModel.kt
@@ -75,6 +75,11 @@ class WishListViewModel @Inject constructor(
         }
     }
 
+    fun deleteWishItem(position: Int, wishItem: WishItem) {
+        wishList.value?.remove(wishItem)
+        wishListAdapter.deleteData(position, wishItem)
+    }
+
     fun getWishList(): LiveData<MutableList<WishItem>?> = wishList
     fun getWishListAdapter(): WishListAdapter = wishListAdapter
 

--- a/app/src/main/res/layout/fragment_wish_item_detail.xml
+++ b/app/src/main/res/layout/fragment_wish_item_detail.xml
@@ -220,6 +220,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="2dp"
                 android:background="@android:color/transparent"
+                android:onClick="@{() -> viewModel.deleteWishItem()}"
                 android:src="@drawable/ic_trash"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
 
     <!-- Detail -->
     <string name="go_to_shop_btn_text">쇼핑몰로 이동하기</string>
+    <string name="wish_item_deletion_toast_text">위시리스트에서 삭제되었습니다</string>
 
     <!-- Notification -->
     <string name="noti_title">알림</string>


### PR DESCRIPTION
## What is this PR? 🔍
상세조회에서 아이템을 삭제할 경우, 서버로 아이템 삭제를 요청하고, 삭제 성공 시 홈화면 ui를 업데이트
## Key Changes 🔑
1. 아이템 삭제 요청 api 및 함수 추가
   - 현재 서버에서 url 변경 작업 중으로, 변경 완료 후 반영 예정
2. 아이템 삭제 성공 시 ui 업데이트
   - 삭제 완료 토스트 띄우기
   - 홈화면으로 복귀
   - 홈화면 > 뷰모델 및 어뎁터의 wishList 에서 삭제된 아이템을 remove
## To Reviewers 📢
- 주목할 부분은 아이템 삭제 할 때 상세조회 -> 메인화면으로 전환할 때 데이터를 전달하는 것입니다!(홈화면 ui 업데이트를 위함)
- 전달 데이터 : `삭제된 아이템 정보`, `adapter > dataset > position 정보`
- 이전 화면으로 복귀 시 `NavController.popBackStack()` 를 사용했었는데, 이번 경우는 복귀할 때 데이터도 함께 전달해야했습니다. 그래서 다음과 같이 코드를 작성했습니다.

```kotlin
navController.previousBackStackEntry?.savedStateHandle?.set(ARG_WISH_ITEM_INFO, bundleOf(
    ARG_WISH_ITEM to viewModel.getWishItem().value,
    ARG_WISH_ITEM_POSITION to position
))
navController.popBackStack()
```
- 부연 설명 : `NavController.getPreviousBackStackEntry()`를 사용하여 이전 화면 `NavBackStackEntry`의 `SavedStateHandle`을 사용해서 전달할 데이터를 설정합니다.

