### PR TITLE
[refactor] WishListViewModel에서 adapter.setData()호출 및 불필요한 wishList 변수 제거

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
@@ -52,14 +52,7 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
         }
     }
 
-    // TODO addObservers() 삭제 -> viewModel에서 adapter.setData() 호출
     private fun addObservers() {
-        viewModel.getWishList().observe(viewLifecycleOwner) {
-            it?.let {
-                adapter.setData(it)
-            }
-        }
-
         // 상세조회에서 아이템 삭제 완료 후 홈으로 복귀했을 때 해당 아이템 정보를 전달받고, ui를 업데이트
         findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Bundle>(
             ARG_WISH_ITEM_INFO


### PR DESCRIPTION
## What is this PR? 🔍
`HomeFragment.kt`에서 호출했던 `wishListAdapter.setData()`를  `WishListViewModel.kt`로 이동 및 불필요한 wishList 변수를 삭제
## Key Changes 🔑
1. `WishListViewModel.kt`내 `fetchWishList()`에서 fetch완료 후 `wishListAdapter.setData()`를 호출하도록 수정
   - 기존 : `HomeFragment.kt`에서 wishList를 observing하면서 `wishListAdapter.setData()` 호출했음
   - 변경 : 뷰모델에서 아이템 fetch, update, delete 시 `wishListAdapter.[set | update | delete]Data(요청 결과 값)`바로 호출하기 때문에 홈에서 wishList를 observe하지 않아도 됨
