### PR TITLE
[feat] 아이템 수정 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -33,6 +33,13 @@ interface RemoteService {
         @Body wishItem: WishItem
     ): Response<RequestResult>
 
+    @PUT("item/{item_id}")
+    suspend fun updateToWishItem(
+        @Header("Authorization") token: String,
+        @Path("item_id") itemId: Long,
+        @Body wishItem: WishItem
+    ): Response<RequestResult>
+
     @DELETE("item/{item_id}")
     suspend fun deleteWishItem(
         @Header("Authorization") token: String,

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepository.kt
@@ -5,5 +5,6 @@ import com.hyeeyoung.wishboard.model.wish.WishItem
 interface WishRepository {
     suspend fun fetchWishList(token: String): List<WishItem>?
     suspend fun uploadWishItem(token: String, wishItem: WishItem): Boolean
+    suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Boolean
     suspend fun deleteWishItem(token: String, itemId: Long): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepositoryImpl.kt
@@ -29,6 +29,17 @@ class WishRepositoryImpl : WishRepository {
         return response.isSuccessful
     }
 
+    override suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Boolean {
+        val response = api.updateToWishItem(token, itemId, wishItem)
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "아이템 수정 성공")
+        } else {
+            Log.e(TAG, "아이템 수정 실패: ${response.code()}")
+        }
+        return response.isSuccessful
+    }
+
     override suspend fun deleteWishItem(token: String, itemId: Long): Boolean {
         val response = api.deleteWishItem(token, itemId)
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishFragment.kt
@@ -13,6 +13,7 @@ import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
+import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -23,12 +24,27 @@ class WishFragment : Fragment() { // TODO rename class name
     private lateinit var binding: FragmentWishBinding
     private val viewModel: WishItemRegistrationViewModel by hiltNavGraphViewModels(R.id.wish_item_registration_nav_graph)
 
+    /** 아이템 수정 여부에 따라 아이템을 update 또는 upload를 진행 (등록 및 수정 시 동일한 뷰를 사용하고 있기 때문) */
+    private var isEditMode = false
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentWishBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
+
+        arguments?.let {
+            (it[ARG_IS_EDIT_MODE] as? Boolean)?.let { isEditable ->
+                isEditMode = isEditable
+            }
+            (it[ARG_WISH_ITEM] as? WishItem)?.let { item ->
+                viewModel.setWishItemInfo(item)
+                item.image?.let { image ->
+                    Glide.with(requireContext()).load(image).into(binding.itemImage)
+                }
+            }
+        }
 
         addListeners()
         addObservers()
@@ -48,7 +64,10 @@ class WishFragment : Fragment() { // TODO rename class name
     private fun addListeners() {
         binding.save.setOnClickListener {
             lifecycleScope.launch {
-                viewModel.uploadWishItemByBasics()
+                when (isEditMode) {
+                    false -> viewModel.uploadWishItemByBasics()
+                    true -> viewModel.updateWishItem()
+                }
             }
         }
 
@@ -86,5 +105,7 @@ class WishFragment : Fragment() { // TODO rename class name
 
     companion object {
         private const val TAG = "WishFragment"
+        private const val ARG_WISH_ITEM = "wishItem"
+        private const val ARG_IS_EDIT_MODE = "isEditMode"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
@@ -15,6 +15,7 @@ import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishItemDetailBinding
 import com.hyeeyoung.wishboard.model.wish.WishItem
+import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.viewmodel.WishItemViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -41,9 +42,19 @@ class WishItemDetailFragment : Fragment() {
             }
         }
 
+        addListeners()
         addObservers()
 
         return binding.root
+    }
+
+    private fun addListeners() {
+        binding.edit.setOnClickListener {
+            findNavController().navigateSafe(R.id.action_detail_to_registration, bundleOf(
+                ARG_WISH_ITEM to viewModel.getWishItem().value,
+                ARG_IS_EDIT_MODE to true
+            ))
+        }
     }
 
     private fun addObservers() {
@@ -82,5 +93,6 @@ class WishItemDetailFragment : Fragment() {
         private const val ARG_WISH_ITEM = "wishItem"
         private const val ARG_WISH_ITEM_POSITION = "position"
         private const val ARG_WISH_ITEM_INFO = "wishItemInfo"
+        private const val ARG_IS_EDIT_MODE = "isEditMode"
     }
 }

--- a/app/src/main/res/layout/fragment_wish.xml
+++ b/app/src/main/res/layout/fragment_wish.xml
@@ -10,6 +10,8 @@
             name="viewModel"
             type="com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel" />
 
+        <import type="androidx.navigation.Navigation" />
+
         <import type="android.view.View" />
     </data>
 
@@ -26,20 +28,16 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-                android:id="@+id/title"
+            <ImageButton
+                android:id="@+id/back"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/noto_sans_kr_bold"
-                android:includeFontPadding="false"
+                android:background="@android:color/transparent"
+                android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}"
                 android:padding="20dp"
-                android:text="@string/item_registration_title"
-                android:textColor="@color/gray_700"
-                android:textSize="20dp"
-                app:layout_constraintBottom_toBottomOf="parent"
+                android:src="@drawable/ic_back"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="@string/item_registration_title" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/save"

--- a/app/src/main/res/menu/bottom_nav.xml
+++ b/app/src/main/res/menu/bottom_nav.xml
@@ -7,15 +7,15 @@
         android:title="home" />
     <!-- TODO id값 snake case로 통일 -->
     <item
-        android:id="@+id/wish_item_registration_nav_graph"
-        android:icon="@drawable/selector_nav_icon_item_registration"
-        android:state_selected="false"
-        android:title="new_item" />
-    <item
         android:id="@+id/folderFragment"
         android:icon="@drawable/selector_nav_icon_folder"
         android:state_selected="false"
         android:title="folder" />
+    <item
+        android:id="@+id/wish_item_registration_nav_graph"
+        android:icon="@drawable/selector_nav_icon_item_registration"
+        android:state_selected="false"
+        android:title="new_item" />
     <item
         android:id="@+id/notiFragment"
         android:icon="@drawable/selector_nav_icon_noti"

--- a/app/src/main/res/navigation/wish_item_nav_graph.xml
+++ b/app/src/main/res/navigation/wish_item_nav_graph.xml
@@ -5,25 +5,15 @@
     android:id="@+id/wish_item_nav_graph"
     app:startDestination="@id/wishItemDetailFragment">
 
+    <include app:graph="@navigation/wish_item_registration_nav_graph" />
+
     <fragment
         android:id="@+id/wishItemDetailFragment"
         android:name="com.hyeeyoung.wishboard.view.wish.item.screens.WishItemDetailFragment"
         android:label="fragment_wish_item_detail"
-        tools:layout="@layout/fragment_wish_item_detail" />
-
-    <fragment
-        android:id="@+id/wishFragment"
-        android:name="com.hyeeyoung.wishboard.view.wish.item.screens.WishFragment"
-        android:label="fragment_wish"
-        tools:layout="@layout/fragment_wish">
+        tools:layout="@layout/fragment_wish_item_detail">
         <action
-            android:id="@+id/action_wish_to_gallery_image"
-            app:destination="@id/galleryImageFragment" />
+            android:id="@+id/action_detail_to_registration"
+            app:destination="@id/wish_item_registration_nav_graph" />
     </fragment>
-
-    <fragment
-        android:id="@+id/galleryImageFragment"
-        android:name="com.hyeeyoung.wishboard.view.common.screens.GalleryImageFragment"
-        android:label="fragment_gallery_image"
-        tools:layout="@layout/fragment_gallery_image" />
 </navigation>


### PR DESCRIPTION
## What is this PR? 🔍
상세조회에서 아이템 수정 버튼을 눌러 수정을 진행할 경우 아이템 정보가 update 되도록 구현
## Key Changes 🔑
1. 수동등록 화면에서 타이틀 "새아이템" 삭제 및 뒤로가기 버튼 추가
   - 아이템 업로드 및 수정에서 동일한 화면을 사용합니다. 이때 상세조회에서 수정버튼을 눌러 `WishFragment.kt`로 진입할 경우, 다시 상세조회로 돌아갈 수 있도록 뒤로가기 버튼을 추가했습니다.
2. BottomNavigationView에서 수동 등록 메뉴 위치만 center로 변경
   - 상품 등록 버튼을 강조하기 위해 상품 등록 버튼을 가운데로 두고, 해당 버튼의 디자인만 포인트를 주려고 함(디자인은 아직 적용 전)
3. wish_item_navigation_graph 코드 정리
4. 아이템 수정 구현
   - 아이템 이미지 변경여부에 따라 이미지파일을 업데이트 여부를 결정
   - 아이템 이미지 변경여부로 케이스를 나누어 아이템 update 테스트해봄 -> 두 케이스 모두 DB update 성공
## To Reviewers 📢
- 아이템 수정 여부에 따라 update, upload를 올바르게 요청하고 있는지 검토 부탁합니다
- `wish_item_registration_nav_graph.xml` 에서 삭제된 코드는 해당 파일 내 추가한 `<include app:graph="@navigation/wish_item_registration_nav_graph" />` 에 해당 코드가 포함되어있습니다! `<include>`로 `wish_item_registration_nav_graph`를 재사용하는 것으로 봐주시면 좋을 것 같습니다!
- 참고로 현재 코드 상으로는 상세조회 -> 수정 완료 -> 상세조회 복귀 시 상세조회 UI 가 업데이트 되지 않습니다! UI 업데이트 부분은 따로 PR올리겠습니다!