### PR TITLE
[feat] 아이템 수정 완료 후 상세조회 ui 업데이트 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.kt
@@ -28,6 +28,7 @@ class MainActivity : AppCompatActivity() {
             it.navController.addOnDestinationChangedListener { _, destination, _ ->
                 when (destination.id) {
                     R.id.cartFragment,
+                    R.id.wishFragment,
                     R.id.wishItemDetailFragment,
                     R.id.galleryImageFragment
                     -> binding.bottomNav.visibility = View.GONE

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
@@ -13,7 +13,7 @@ data class WishItem(
     @SerializedName("item_id")
     val id: Long? = null,
     @SerializedName("item_img")
-    val image: String? = null,
+    var image: String? = null, // TODO 추후 val로 다시 변경 예정.
     @SerializedName("item_name")
     val name: String,
     @SerializedName("item_price")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="memo_input_text">메모를 작성해 보세요.</string>
     <string name="wish_item_registration_toast_text">위시리스트에 추가되었습니다</string>
     <string name="wish_item_registration_gallery_image_title">사진 선택하기</string>
+    <string name="wish_item_update_toast_text">상품 수정이 완료되었습니다.</string>
+    <string name="wish_item_upload_toast_text">상품 등록이 완료되었습니다.</string>
 
     <!-- Detail -->
     <string name="go_to_shop_btn_text">쇼핑몰로 이동하기</string>


### PR DESCRIPTION
## What is this PR? 🔍
아이템 수정 완료 후 상세조회 ui 업데이트 구현
## Key Changes 🔑
1. 아이템 등록(수정) 화면 진입 시 `BottomNavigationView` 숨김
   - 수정 중 하단 메뉴를 실수로 눌러 탭 전환되는 문제를 방지하고 함
   - 임시저장 기능을 구현하면 굳이 숨기지 않아도 됨. 임시저장은 배포 이후 도입
2. 상품 등록 및 수정 시 띄울 `토스트 메세지` 추가
3. 아이템 수정 완료 후 수정된 아이템 정보를 `DetailFragment` 로 전달 -> 상세조회 ui 업데이트
4. `WishItem.kt` > `image` 프로퍼티 
   - `val` -> `var`로 임시 변경
   - 리팩토링 이후 원상복구 예정
## To Reviewers 📢
- 현재 홈 -> 상세조회 -> 수동등록으로 진입한 경우, 이미지를 변경하지 않았을 때의 `wishItem.image` :
   - `"http~" 로 시작하는 이미지 url` -> S3에서 이미지 url을 다운로드 받지 않아도 됨
- 이미지 수정 완료 -> 상세조회 -> 수동등록(재수정)으로 진입한 경우, 이미지는 변경하지 않았을 때의 `wishItem.image` : 
   - `이미지 파일명` -> S3에서 파일명으로 이미지 url 다운로드 받아야함
- 두 가지 경우에 따라 이미지 load 전 이미지 url을 다운로드 함
- 리팩토링 이후 후자로 통일 예정 -> 리팩토링 완료! 아침에 일어나서 변수명 고민 좀 하고 PR 올릴게요..