### PR TITLE
폴더 조회 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/folder/FolderItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/folder/FolderItem.kt
@@ -12,6 +12,6 @@ data class FolderItem(
     val name: String,
     @SerializedName("folder_img")
     val image: String? = null, // TODO 논의 후 삭제 결정 및 썸네일 이미지(해당 폴더 내 최근 아이템) 추가
-    @SerializedName("folder_item_count")
+    @SerializedName("item_count")
     val itemCount: Int? = null,
 ): Parcelable

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/folder/FolderItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/folder/FolderItem.kt
@@ -7,7 +7,7 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class FolderItem(
     @SerializedName("folder_id")
-    val folderId: Long? = null,
+    val id: Long? = null,
     @SerializedName("folder_name")
     val name: String,
     @SerializedName("folder_img")

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -58,18 +58,17 @@ interface RemoteService {
         @Field("item_id") itemId: Long
     ): Response<RequestResult>
 
-    @FormUrlEncoded
-    @HTTP(method = "DELETE", path = "cart", hasBody = true)
+    @DELETE("cart/{item_id}")
     suspend fun removeToCart(
         @Header("Authorization") token: String,
-        @Field("item_id") itemId: Long
+        @Path("item_id") itemId: Long
     ): Response<RequestResult>
 
     @FormUrlEncoded
-    @PUT("cart")
+    @PUT("cart/{item_id}")
     suspend fun updateToCart(
         @Header("Authorization") token: String,
-        @Field("item_id") itemId: Long,
+        @Path("item_id") itemId: Long,
         @Field("item_count") itemCount: Int
     ): Response<RequestResult>
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -73,6 +73,17 @@ interface RemoteService {
     ): Response<RequestResult>
 
     // 폴더
+    @GET("folder")
+    suspend fun fetchFolderList(
+        @Header("Authorization") token: String
+    ): Response<List<FolderItem>>?
+
+    @GET("folder/item/{folder_id}")
+    suspend fun fetchItemsInFolder(
+        @Header("Authorization") token: String,
+        @Path("folder_id") folderId: Long
+    ): Response<List<WishItem>>?
+
     @POST("folder")
     suspend fun createNewFolder(
         @Header("Authorization") token: String,

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
@@ -1,7 +1,10 @@
 package com.hyeeyoung.wishboard.repository.folder
 
 import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.model.wish.WishItem
 
 interface FolderRepository {
+    suspend fun fetchFolderList(token: String): List<FolderItem>?
+    suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>?
     suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
@@ -2,10 +2,33 @@ package com.hyeeyoung.wishboard.repository.folder
 
 import android.util.Log
 import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.remote.RemoteService
 
 class FolderRepositoryImpl : FolderRepository {
     private val api = RemoteService.api
+
+    override suspend fun fetchFolderList(token: String): List<FolderItem>? {
+        val response = api.fetchFolderList(token) ?: return null
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "폴더 가져오기 성공")
+        } else {
+            Log.e(TAG, "폴더 가져오기 실패: ${response.code()}")
+        }
+        return response.body()
+    }
+
+    override suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>? {
+        val response = api.fetchItemsInFolder(token, folderId) ?: return null
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "폴더 내 아이템 가져오기 성공")
+        } else {
+            Log.e(TAG, "폴더 내 아이템 가져오기 실패: ${response.code()}")
+        }
+        return response.body()
+    }
 
     override suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean {
         val response = api.createNewFolder(token, folderItemInfo)

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
@@ -4,16 +4,17 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.databinding.ItemCartBinding
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.cart.CartItemButtonType
+import com.hyeeyoung.wishboard.util.ImageLoader
 
 class CartListAdapter(
     private val context: Context
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val dataSet = arrayListOf<CartItem>()
     private lateinit var listener: OnItemClickListener
+    private lateinit var imageLoader: ImageLoader
 
     interface OnItemClickListener {
         fun onItemClick(item: CartItem, position: Int, viewType: CartItemButtonType)
@@ -23,6 +24,10 @@ class CartListAdapter(
         this.listener = listener
     }
 
+    fun setImageLoader(imageLoader: ImageLoader) {
+        this.imageLoader = imageLoader
+    }
+
     inner class ViewHolder(private val binding: ItemCartBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(position: Int) {
@@ -30,7 +35,8 @@ class CartListAdapter(
 
             with(binding) {
                 this.item = item
-                Glide.with(context).load(item.wishItem.image).into(itemImage)
+                item.wishItem.image?.let { imageLoader.loadImage(it, binding.itemImage) }
+
                 delete.setOnClickListener {
                     listener.onItemClick(item, position, CartItemButtonType.VIEW_TYPE_DELETION)
                     removeItem(position)

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/screens/CartFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/screens/CartFragment.kt
@@ -4,9 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -14,13 +16,15 @@ import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentCartBinding
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.cart.CartItemButtonType
+import com.hyeeyoung.wishboard.util.ImageLoader
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
+import com.hyeeyoung.wishboard.util.loadImage
 import com.hyeeyoung.wishboard.view.cart.adapters.CartListAdapter
 import com.hyeeyoung.wishboard.viewmodel.CartViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class CartFragment : Fragment(), CartListAdapter.OnItemClickListener {
+class CartFragment : Fragment(), CartListAdapter.OnItemClickListener, ImageLoader {
     private lateinit var binding: FragmentCartBinding
     private val viewModel: CartViewModel by viewModels()
 
@@ -40,6 +44,7 @@ class CartFragment : Fragment(), CartListAdapter.OnItemClickListener {
     private fun initializeView() {
         val adapter = viewModel.getCartListAdapter()
         adapter.setOnItemClickListener(this)
+        adapter.setImageLoader(this)
         binding.cartList.run {
             this.adapter = adapter
             layoutManager = LinearLayoutManager(requireContext())
@@ -67,6 +72,10 @@ class CartFragment : Fragment(), CartListAdapter.OnItemClickListener {
                 viewModel.controlItemCount(item, position, viewType)
             }
         }
+    }
+
+    override fun loadImage(imageUrl: String, imageView: ImageView) {
+        loadImage(lifecycleScope, requireContext(), imageUrl, imageView)
     }
 
     companion object {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -89,5 +89,6 @@ class FolderListAdapter(
     fun setData(items: List<FolderItem>) {
         dataSet.clear()
         dataSet.addAll(items)
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -4,31 +4,53 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.GridLayoutManager
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentFolderBinding
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
+import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
+import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
-class FolderFragment : Fragment() {
+@AndroidEntryPoint
+class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener {
     private lateinit var binding: FragmentFolderBinding
+    private val viewModel: FolderViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentFolderBinding.inflate(inflater, container, false)
+        binding.viewModel = viewModel
 
+        initializeView()
         addListeners()
         addObservers()
 
         return binding.root
     }
 
+    private fun initializeView() {
+        val adapter = viewModel.getFolderListAdapter()
+        adapter.setOnItemClickListener(this)
+        binding.folderList.adapter = adapter
+        binding.folderList.layoutManager = GridLayoutManager(requireContext(), 2)
+
+    }
+
     private fun addListeners() {
         binding.newFolder.setOnClickListener {
             findNavController().navigateSafe(R.id.action_folder_to_folder_add_dialog)
+        }
+        binding.swipeRefresh.setOnRefreshListener {
+            viewModel.fetchFolderList()
+            binding.swipeRefresh.isRefreshing = false
         }
     }
 
@@ -37,6 +59,13 @@ class FolderFragment : Fragment() {
             ARG_FOLDER_ITEM
         )?.observe(viewLifecycleOwner) {
         }
+    }
+
+    override fun onItemClick(item: FolderItem) {
+        findNavController().navigateSafe(
+            R.id.action_folder_to_folder_detail,
+            bundleOf(ARG_FOLDER_ITEM to item)
+        )
     }
 
     companion object {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -35,7 +35,7 @@ class WishListAdapter(
             val item = dataSet[position]
             with(binding) {
                 this.item = item
-                imageLoader.loadImage(item.image ?: return@with, binding.itemImage)
+                item.image?.let { imageLoader.loadImage(it, binding.itemImage) }
                 binding.cart.isSelected = item.cartState == CartStateType.IN_CART.numValue
 
                 container.setOnClickListener {

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -1,0 +1,40 @@
+package com.hyeeyoung.wishboard.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hyeeyoung.wishboard.model.folder.FolderListViewType
+import com.hyeeyoung.wishboard.repository.folder.FolderRepository
+import com.hyeeyoung.wishboard.util.prefs
+import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class FolderViewModel @Inject constructor(
+    private val application: Application,
+    private val folderRepository: FolderRepository,
+) : ViewModel() {
+    private val token = prefs?.getUserToken()
+
+    private val folderListAdapter =
+        FolderListAdapter(application, FolderListViewType.SQUARE_VIEW_TYPE)
+
+    init {
+        fetchFolderList()
+    }
+
+    fun fetchFolderList() {
+        if (token == null) return
+        viewModelScope.launch {
+            folderListAdapter.setData(folderRepository.fetchFolderList(token) ?: return@launch)
+        }
+    }
+
+    fun getFolderListAdapter(): FolderListAdapter = folderListAdapter
+
+    companion object {
+        private const val TAG = "FolderViewModel"
+    }
+}

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -4,6 +4,13 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".view.folder.screens.FolderFragment">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.hyeeyoung.wishboard.viewmodel.FolderViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
@@ -51,7 +58,6 @@
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <!--    @brief : 밑으로 당겨서 refresh를 위해 추가 -->
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/swipeRefresh"
             android:layout_width="match_parent"
@@ -60,7 +66,7 @@
             app:layout_constraintTop_toBottomOf="@id/title_container">
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerview_folders_list"
+                android:id="@+id/folder_list"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:padding="10dp"

--- a/app/src/main/res/layout/fragment_folder_detail.xml
+++ b/app/src/main/res/layout/fragment_folder_detail.xml
@@ -2,18 +2,27 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="">
+    tools:context="com.hyeeyoung.wishboard.view.folder.screens.FolderDetailFragment">
+
+    <data>
+
+        <import type="androidx.navigation.Navigation" />
+
+        <variable
+            name="viewModel"
+            type="com.hyeeyoung.wishboard.viewmodel.WishListViewModel" />
+    </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/white">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/title_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="20dp"
-            android:padding="20dp"
             app:layout_constraintTop_toTopOf="parent">
 
             <ImageButton
@@ -21,7 +30,11 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_centerVertical="true"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
                 android:background="@android:color/transparent"
+                android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}"
+                android:padding="@dimen/spacing12"
                 android:src="@drawable/ic_back"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -29,8 +42,10 @@
             <ImageButton
                 android:id="@+id/more"
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_height="0dp"
+                android:layout_marginEnd="8dp"
                 android:background="@android:color/transparent"
+                android:padding="@dimen/spacing12"
                 android:src="@drawable/ic_more"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -44,16 +59,16 @@
             android:fontFamily="@font/nanum_square_eb"
             android:paddingHorizontal="20dp"
             android:paddingBottom="10dp"
+            android:text="@{viewModel.folderItem.name}"
             android:textColor="@color/gray_700"
             android:textSize="15dp"
             app:layout_constraintTop_toBottomOf="@id/title_container"
             tools:text="폴더명" />
 
         <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerview_folders_detail"
+            android:id="@+id/wish_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:padding="10dp"
             android:scrollbarFadeDuration="0"
             android:scrollbarSize="5dp"
             android:scrollbarThumbVertical="@android:color/darker_gray"

--- a/app/src/main/res/layout/item_folder_square.xml
+++ b/app/src/main/res/layout/item_folder_square.xml
@@ -17,11 +17,11 @@
         android:background="@color/white"
         android:padding="10dp">
 
-        <!-- @brief : 폴더화면 아이템 리스트 중 아이템 하나의 뷰 -->
         <ImageView
             android:id="@+id/folder_image"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:foreground="@color/ultraSemiTransparent"
             android:scaleType="centerCrop"
             app:layout_constraintDimensionRatio="1:1"
             app:layout_constraintEnd_toEndOf="parent"
@@ -29,43 +29,49 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/sample" />
 
-        <TextView
-            android:id="@+id/folder_name"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginLeft="2dp"
-            android:layout_marginTop="10dp"
-            android:fontFamily="@font/nanum_square_eb"
-            android:text="@{item.name}"
-            android:textColor="@color/gray_700"
-            android:textSize="13dp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="parent"
-            tools:text="폴더명" />
+            app:layout_constraintTop_toBottomOf="@id/folder_image">
 
-        <TextView
-            android:id="@+id/item_count"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="5dp"
-            android:fontFamily="@font/nanum_square_b"
-            android:textColor="@color/gray_200"
-            android:textSize="13dp"
-            app:layout_constraintStart_toStartOf="@id/folder_name"
-            app:layout_constraintTop_toBottomOf="@id/folder_name"
-            tools:text="10" />
+            <TextView
+                android:id="@+id/folder_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="2dp"
+                android:layout_marginTop="10dp"
+                android:fontFamily="@font/nanum_square_eb"
+                android:text="@{item.name}"
+                android:textColor="@color/gray_700"
+                android:textSize="13sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="폴더명" />
 
-        <ImageButton
-            android:id="@+id/more_folder"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="2dp"
-            android:background="@android:color/transparent"
-            android:onClick="onClick"
-            android:paddingBottom="15dp"
-            android:src="@drawable/ic_folder_more"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/folder_name" />
+            <TextView
+                android:id="@+id/item_count"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="5dp"
+                android:fontFamily="@font/nanum_square_b"
+                android:text="@{Integer.toString(item.itemCount != null ? item.itemCount : 0)}"
+                android:textColor="@color/gray_200"
+                android:textSize="13sp"
+                app:layout_constraintStart_toStartOf="@id/folder_name"
+                app:layout_constraintTop_toBottomOf="@id/folder_name"
+                tools:text="10" />
 
+            <ImageButton
+                android:id="@+id/more_folder"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="2dp"
+                android:background="@android:color/transparent"
+                android:paddingBottom="15dp"
+                android:src="@drawable/ic_folder_more"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/folder_name" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -41,6 +41,9 @@
         <action
             android:id="@+id/action_folder_to_folder_add_dialog"
             app:destination="@id/folderAddDialog" />
+        <action
+            android:id="@+id/action_folder_to_folder_detail"
+            app:destination="@id/folderDetailFragment" />
     </fragment>
     <fragment
         android:id="@+id/notiFragment"
@@ -56,6 +59,15 @@
         android:name="com.hyeeyoung.wishboard.view.my.screens.MyFragment"
         android:label="fragment_my"
         tools:layout="@layout/fragment_my" />
+    <fragment
+        android:id="@+id/folderDetailFragment"
+        android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderDetailFragment"
+        android:label="fragment_folder_detail"
+        tools:layout="@layout/fragment_folder_detail" >
+        <action
+            android:id="@+id/action_folder_detail_to_wish_item_detail"
+            app:destination="@id/wish_item_nav_graph" />
+    </fragment>
 
     <!-- TODO id -> snake_case, label -> camelCase로 변경하기 -->
     <dialog


### PR DESCRIPTION
## What is this PR? 🔍

## Key Changes 🔑
1. `FolderItem.kt` 
   - `itemCount` SerializedName 변경 : `"folder_item_count"` -> `"item_count"` 로 변경
   - 프로퍼티 변경 `folderId` -> `id`로 변경
2. `RemoteService.kt` 폴더 조회요청 url 추가
   - 폴더 탭 폴더 리스트 조회
   - 특정 폴더 내 아이템 조회
3. 폴더 조회 관련 프로세스 및 UI 구현
   - `FolderFragment.kt` : 폴더 탭 조회 프로세스를 `FolderViewModel.kt`에 구현
   - `FolderDetailFragment.kt` : 특정 폴더 내 아이템 조회 프로세스를 `WishListViewModel`에 구현
## To Reviewers 📢
- `RemoteService.kt`에서 cart 관련 요청 url이 변경 및 cartListAdapter에 ImageLoader 적용이 이번 PR에 함께 포함되었습니다.. 양해 부탁드립니다🥲
- `FolderDetailFragment.kt`의 경우` FolderViewModel`가 아닌 `WishListViewModel`에서 프로세스를 구현한 이유
   - 장바구니 버튼 토글 기능 등 `WishListViewModel` 구현한 함수를 재사용하기 위함.
- `WishListViewModel` 실행 시 `fetchWishList()`(홈화면 위시리스트 fetch) 이 바로 호출되었는데, `FolderDetailFragment`에서도 해당 뷰모델을 사용하게 되면서 `fetchWishList()`의 위치를 `init 블록 내부` -> `HomeFragment > onCreateView()`로 이동
   - `FolderDetailFragment`의 경우 `fetchWishList()`를 실행할 필요가 없기 때문. `fetchFolderItems(folderId: Long?)` 실행해야함.
   - init 블록 내에서 진입 화면에 따라 분기 처리 못함