### PR TITLE
[feat] 아이템 수동 등록 내 폴더 리스트 조회 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.kt
@@ -30,6 +30,7 @@ class MainActivity : AppCompatActivity() {
                     R.id.cartFragment,
                     R.id.wishFragment,
                     R.id.wishItemDetailFragment,
+                    R.id.folderListFragment,
                     R.id.galleryImageFragment
                     -> binding.bottomNav.visibility = View.GONE
                     else -> binding.bottomNav.visibility = View.VISIBLE

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -78,6 +78,11 @@ interface RemoteService {
         @Header("Authorization") token: String
     ): Response<List<FolderItem>>?
 
+    @GET("folder/list")
+    suspend fun fetchFolderListSummary(
+        @Header("Authorization") token: String
+    ): Response<List<FolderItem>>?
+
     @GET("folder/item/{folder_id}")
     suspend fun fetchItemsInFolder(
         @Header("Authorization") token: String,

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
@@ -5,6 +5,7 @@ import com.hyeeyoung.wishboard.model.wish.WishItem
 
 interface FolderRepository {
     suspend fun fetchFolderList(token: String): List<FolderItem>?
+    suspend fun fetchFolderListSummary(token: String): List<FolderItem>?
     suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>?
     suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
@@ -19,6 +19,17 @@ class FolderRepositoryImpl : FolderRepository {
         return response.body()
     }
 
+    override suspend fun fetchFolderListSummary(token: String): List<FolderItem>? {
+        val response = api.fetchFolderListSummary(token) ?: return null
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "폴더 요약본 가져오기 성공")
+        } else {
+            Log.e(TAG, "폴더 요약본 가져오기 실패: ${response.code()}")
+        }
+        return response.body()
+    }
+
     override suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>? {
         val response = api.fetchItemsInFolder(token, folderId) ?: return null
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -4,11 +4,11 @@ import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.databinding.ItemFolderHorizontalBinding
 import com.hyeeyoung.wishboard.databinding.ItemFolderSquareBinding
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderListViewType
+import com.hyeeyoung.wishboard.util.ImageLoader
 
 class FolderListAdapter(
     private val context: Context,
@@ -16,6 +16,7 @@ class FolderListAdapter(
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private val dataSet = arrayListOf<FolderItem>()
     private lateinit var listener: OnItemClickListener
+    private lateinit var imageLoader: ImageLoader
 
     interface OnItemClickListener {
         fun onItemClick(item: FolderItem)
@@ -25,6 +26,10 @@ class FolderListAdapter(
         this.listener = listener
     }
 
+    fun setImageLoader(imageLoader: ImageLoader) {
+        this.imageLoader = imageLoader
+    }
+
     inner class SquareViewHolder(private val binding: ItemFolderSquareBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(position: Int) {
@@ -32,7 +37,7 @@ class FolderListAdapter(
 
             with(binding) {
                 this.item = item
-                Glide.with(context).load(item.thumbnail).into(folderImage)
+                item.thumbnail?.let { imageLoader.loadImage(it, thumbnail) }
                 container.setOnClickListener {
                     listener.onItemClick(item)
                 }
@@ -47,7 +52,7 @@ class FolderListAdapter(
 
             with(binding) {
                 this.item = item
-                Glide.with(context).load(item.thumbnail).into(folderImage)
+                item.thumbnail?.let { imageLoader.loadImage(it, thumbnail) }
                 container.setOnClickListener {
                     listener.onItemClick(item)
                 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -29,6 +29,8 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener {
         binding = FragmentFolderBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
 
+        viewModel.fetchFolderList()
+
         initializeView()
         addListeners()
         addObservers()

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
@@ -5,21 +5,50 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.hyeeyoung.wishboard.databinding.FragmentFolderListBinding
+import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
+import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
+import dagger.hilt.android.AndroidEntryPoint
 
-class FolderListFragment : Fragment() {
+@AndroidEntryPoint
+class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener {
     private lateinit var binding: FragmentFolderListBinding
+    private val viewModel: FolderViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         binding = FragmentFolderListBinding.inflate(inflater, container, false)
+        binding.viewModel = viewModel
+
+        viewModel.fetchFolderListSummary()
+
+        initializeView()
 
         return binding.root
     }
 
+    private fun initializeView() {
+        val adapter = viewModel.getFolderListSummaryAdapter()
+        adapter.setOnItemClickListener(this)
+        binding.folderList.adapter = adapter
+        binding.folderList.layoutManager = LinearLayoutManager(requireContext())
+    }
+
+    override fun onItemClick(item: FolderItem) {
+        findNavController().apply {
+            previousBackStackEntry?.savedStateHandle?.set(ARG_FOLDER_ITEM, item)
+            popBackStack()
+        }
+    }
+
     companion object {
-       private const val TAG = "FolderListFragment"
+        private const val TAG = "FolderListFragment"
+        private const val ARG_FOLDER_ITEM = "folderItem"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -15,10 +15,12 @@ import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
+import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.util.ImageLoader
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.loadImage
+import com.hyeeyoung.wishboard.view.folder.screens.FolderListFragment
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -82,9 +84,11 @@ class WishBasicFragment : Fragment(), ImageLoader {
                 }
             }
         }
-
-        binding.itemImageLayout.setOnClickListener {
+        binding.itemImageLayout.setOnClickListener { // TODO itemImageContainer로 변경
             requestStorage.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+        binding.folderContainer.setOnClickListener {
+            findNavController().navigateSafe(R.id.action_wish_to_folder_list)
         }
     }
 
@@ -123,6 +127,13 @@ class WishBasicFragment : Fragment(), ImageLoader {
                 Glide.with(requireContext()).load(uri).into(binding.itemImage)
             }
         }
+
+        // 폴더 리스트에서 선택한 폴더 정보를 전달받음
+        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<FolderItem>(
+            ARG_FOLDER_ITEM
+        )?.observe(viewLifecycleOwner) { folder ->
+            viewModel.setFolderItem(folder)
+        }
     }
 
     private val requestStorage =
@@ -141,5 +152,6 @@ class WishBasicFragment : Fragment(), ImageLoader {
         private const val TAG = "WishBasicFragment"
         private const val ARG_WISH_ITEM = "wishItem"
         private const val ARG_IS_EDIT_MODE = "isEditMode"
+        private const val ARG_FOLDER_ITEM = "folderItem"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -20,10 +20,8 @@ class FolderViewModel @Inject constructor(
 
     private val folderListAdapter =
         FolderListAdapter(application, FolderListViewType.SQUARE_VIEW_TYPE)
-
-    init {
-        fetchFolderList()
-    }
+    private val folderListSummaryAdapter =
+        FolderListAdapter(application, FolderListViewType.HORIZONTAL_VIEW_TYPE)
 
     fun fetchFolderList() {
         if (token == null) return
@@ -32,7 +30,17 @@ class FolderViewModel @Inject constructor(
         }
     }
 
+    fun fetchFolderListSummary() {
+        if (token == null) return
+        viewModelScope.launch {
+            folderListSummaryAdapter.setData(
+                folderRepository.fetchFolderListSummary(token) ?: return@launch
+            )
+        }
+    }
+
     fun getFolderListAdapter(): FolderListAdapter = folderListAdapter
+    fun getFolderListSummaryAdapter(): FolderListAdapter = folderListSummaryAdapter
 
     companion object {
         private const val TAG = "FolderViewModel"

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
@@ -15,6 +15,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.remote.AWSS3Service
 import com.hyeeyoung.wishboard.repository.common.GalleryPagingDataSource
@@ -50,6 +51,8 @@ class WishItemRegistrationViewModel @Inject constructor(
     private var itemImage = MutableLiveData<String>()
     private var itemMemo = MutableLiveData<String>()
     private var itemUrl = MutableLiveData<String>()
+    private var folderItem: FolderItem? = null
+
     private var isCompleteUpload = MutableLiveData<Boolean?>()
 
     private val galleryImageUris = MutableLiveData<PagingData<Uri>>()
@@ -132,7 +135,9 @@ class WishItemRegistrationViewModel @Inject constructor(
                     image = file.name,
                     price = itemPrice.value?.toIntOrNull(),
                     url = itemUrl.value,
-                    memo = itemMemo.value?.trim()
+                    memo = itemMemo.value?.trim(),
+                    folderId = folderItem?.id,
+                    folderName = folderItem?.name // TODO (보류) 현재 코드 상으로는 folderId만 필요한 것으로 파악되나 추후 수동등록화면에서 폴더 추가기능 도입할 경우 필요함
                 )
                 val isComplete = wishRepository.uploadWishItem(token, item)
                 isCompleteUpload.postValue(isComplete)
@@ -159,8 +164,8 @@ class WishItemRegistrationViewModel @Inject constructor(
                 price = itemPrice.value?.toIntOrNull(),
                 url = itemUrl.value,
                 memo = itemMemo.value?.trim(),
-                folderId = wishItem?.folderId,
-                folderName = wishItem?.folderName,
+                folderId = folderItem?.id ?: wishItem?.folderId,
+                folderName = folderItem?.name ?: wishItem?.folderName, // TODO (보류) 현재 코드 상으로는 folderId만 필요한 것으로 파악되나 추후 수동등록화면에서 폴더 추가기능 도입할 경우 필요함
                 notiDate = wishItem?.notiDate,
                 notiType = wishItem?.notiType
             )
@@ -286,6 +291,10 @@ class WishItemRegistrationViewModel @Inject constructor(
         itemMemo.value = s.toString()
     }
 
+    fun setFolderItem(folder: FolderItem) {
+        folderItem = folder
+    }
+
     fun setItemUrl(url: String) {
         itemUrl.value = url
     }
@@ -311,6 +320,7 @@ class WishItemRegistrationViewModel @Inject constructor(
     fun getItemPrice(): LiveData<String> = itemPrice
     fun getItemUrl(): LiveData<String> = itemUrl
     fun getItemMemo(): LiveData<String> = itemMemo
+    fun getFolderItem(): FolderItem? = folderItem
     fun isCompleteUpload(): LiveData<Boolean?> = isCompleteUpload
 
     fun getGalleryImageUris(): LiveData<PagingData<Uri>?> = galleryImageUris

--- a/app/src/main/res/layout/fragment_folder_list.xml
+++ b/app/src/main/res/layout/fragment_folder_list.xml
@@ -4,12 +4,22 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="com.hyeeyoung.wishboard.view.folder.screens.FolderListFragment">
 
+    <data>
+
+        <import type="androidx.navigation.Navigation" />
+
+        <variable
+            name="viewModel"
+            type="com.hyeeyoung.wishboard.viewmodel.FolderViewModel" />
+    </data>
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white"
         android:orientation="vertical">
 
+        <!-- TODO padding 조정 -->
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -20,6 +30,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
+                android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}"
                 android:src="@drawable/ic_back"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -46,7 +57,7 @@
             android:layout_height="match_parent">
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/recyclerview_folders_selected"
+                android:id="@+id/folder_list"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:scrollbarFadeDuration="0"

--- a/app/src/main/res/layout/fragment_wish.xml
+++ b/app/src/main/res/layout/fragment_wish.xml
@@ -114,7 +114,7 @@
                     app:layout_constraintTop_toBottomOf="@id/item_image_layout">
 
                     <LinearLayout
-                        android:id="@+id/btn_folder"
+                        android:id="@+id/folder_container"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content">
 
@@ -133,6 +133,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginHorizontal="5dp"
+                            android:text="@{viewModel.folderItem.name == null ? viewModel.wishItem.folderName : viewModel.folderItem.name}"
                             android:fontFamily="@font/nanum_square_b"
                             android:textColor="@color/gray_700"
                             android:textSize="13dp" />

--- a/app/src/main/res/layout/item_folder_horizontal.xml
+++ b/app/src/main/res/layout/item_folder_horizontal.xml
@@ -19,36 +19,37 @@
         android:paddingVertical="10dp">
 
         <de.hdodenhof.circleimageview.CircleImageView
-            android:id="@+id/folder_image"
+            android:id="@+id/thumbnail"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:background="@android:color/transparent"
+            android:foreground="@color/ultraSemiTransparent"
             android:scaleType="centerCrop"
-            android:src="@drawable/sample"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            tools:src="@drawable/sample" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
+            android:layout_marginStart="5dp"
             android:gravity="center_vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/folder_image"
+            app:layout_constraintStart_toEndOf="@id/thumbnail"
             app:layout_constraintTop_toTopOf="parent">
 
             <TextView
                 android:id="@+id/folder_name"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginHorizontal="20dp"
+                android:layout_marginEnd="20dp"
                 android:layout_weight="1"
                 android:fontFamily="@font/nanum_square_b"
                 android:text="@{item.name}"
                 android:textColor="@color/gray_700"
-                android:textSize="15dp"
+                android:textSize="15sp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toStartOf="@id/btn_radio"
                 app:layout_constraintStart_toStartOf="parent"
@@ -61,7 +62,6 @@
                 android:layout_height="wrap_content"
                 android:background="@android:color/transparent"
                 android:button="@drawable/selector_checkbox"
-                android:onClick="onClick"
                 android:state_checked="false"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_folder_square.xml
+++ b/app/src/main/res/layout/item_folder_square.xml
@@ -18,7 +18,7 @@
         android:padding="10dp">
 
         <ImageView
-            android:id="@+id/folder_image"
+            android:id="@+id/thumbnail"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:foreground="@color/ultraSemiTransparent"
@@ -32,7 +32,7 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/folder_image">
+            app:layout_constraintTop_toBottomOf="@id/thumbnail">
 
             <TextView
                 android:id="@+id/folder_name"

--- a/app/src/main/res/navigation/wish_item_registration_nav_graph.xml
+++ b/app/src/main/res/navigation/wish_item_registration_nav_graph.xml
@@ -13,6 +13,9 @@
         <action
             android:id="@+id/action_wish_to_gallery_image"
             app:destination="@id/galleryImageFragment" />
+        <action
+            android:id="@+id/action_wish_to_folder_list"
+            app:destination="@id/folderListFragment" />
     </fragment>
 
     <fragment
@@ -20,4 +23,10 @@
         android:name="com.hyeeyoung.wishboard.view.common.screens.GalleryImageFragment"
         android:label="fragment_gallery_image"
         tools:layout="@layout/fragment_gallery_image"/>
+
+    <fragment
+        android:id="@+id/folderListFragment"
+        android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderListFragment"
+        android:label="fragment_folder_list"
+        tools:layout="@layout/fragment_folder_list"/>
 </navigation>


### PR DESCRIPTION
## What is this PR? 🔍
아이템 수동 등록 내에서 폴더 리스트 조회 및 아이템 업로드 시 폴더 정보를 설정하는 기능을 구현
## Key Changes 🔑
1. `FolderListFragment` 진입 시 하단 네이게이션 뷰 숨김 처리
2. 수동 등록 내 폴더리스트 조회 프로세스 구현
   - `fetchFolderList` : 폴더탭 폴더리스트 조회
   - ``fetchFolderListSummary` : 수동등록 내 폴더리스트 조회
      - 기존 폴더탭 내 폴더리스트 조회 요청 함수와 구분하기 위해 Summary를 붙임 // 실제 요약본을 가져오기도 하기 때문
3. 수동 등록 내 폴더리스트 조회 UI 구현 
   - `FolderListFragment` 에서 폴더를 선택할 경우, 바로 이전화면으로 돌아가면서 폴더명이 보이도록 UI를 수정
4. 아이템 업로드 또는 수정 시 폴더 정보까지 저장하도록 구현
## To Reviewers 📢
- `FolderListFragment` 내 리사이클러 뷰 아이템에서 체크박스를 삭제하는 것이 좋을 것 같음. 다음주 회의 때 논의할 예정
   - 3번으로 변경되었기 때문
