### PR TITLE
폴더 삭제 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -95,6 +95,12 @@ interface RemoteService {
         @Body folderItem: FolderItem
     ): Response<RequestResult>
 
+    @DELETE("folder/{folder_id}")
+    suspend fun deleteFolder(
+        @Header("Authorization") token: String,
+        @Path("folder_id") folderId: Long,
+    ): Response<RequestResult>
+
     companion object {
         val api = Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
@@ -8,4 +8,5 @@ interface FolderRepository {
     suspend fun fetchFolderListSummary(token: String): List<FolderItem>?
     suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>?
     suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean
+    suspend fun deleteFolder(token: String, folderId: Long): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.remote.RemoteService
+import com.hyeeyoung.wishboard.repository.wish.WishRepositoryImpl
 
 class FolderRepositoryImpl : FolderRepository {
     private val api = RemoteService.api
@@ -48,6 +49,17 @@ class FolderRepositoryImpl : FolderRepository {
             Log.d(TAG, "폴더 추가 성공")
         } else {
             Log.e(TAG, "폴더 추가 실패: ${response.code()}")
+        }
+        return response.isSuccessful
+    }
+
+    override suspend fun deleteFolder(token: String, folderId: Long): Boolean {
+        val response = api.deleteFolder(token, folderId)
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "폴더 삭제 성공")
+        } else {
+            Log.e(TAG, "폴더 삭제 실패: ${response.code()}")
         }
         return response.isSuccessful
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -3,12 +3,16 @@ package com.hyeeyoung.wishboard.view.folder.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.RecyclerView
+import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.ItemFolderHorizontalBinding
 import com.hyeeyoung.wishboard.databinding.ItemFolderSquareBinding
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderListViewType
 import com.hyeeyoung.wishboard.util.ImageLoader
+import com.hyeeyoung.wishboard.util.extension.navigateSafe
 
 class FolderListAdapter(
     private val context: Context,
@@ -40,6 +44,12 @@ class FolderListAdapter(
                 item.thumbnail?.let { imageLoader.loadImage(it, thumbnail) }
                 container.setOnClickListener {
                     listener.onItemClick(item)
+                }
+                moreFolder.setOnClickListener {
+                    it.findNavController().navigateSafe(R.id.action_folder_to_folder_more_dialog, bundleOf(
+                        ARG_FOLDER_ITEM to item,
+                        ARG_FOLDER_POSITION to position
+                    ))
                 }
             }
         }
@@ -91,9 +101,20 @@ class FolderListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+
+    fun deleteData(position: Int, folderItem: FolderItem) {
+        dataSet.remove(folderItem)
+        notifyItemRemoved(position)
+    }
+
     fun setData(items: List<FolderItem>) {
         dataSet.clear()
         dataSet.addAll(items)
         notifyDataSetChanged()
+    }
+
+    companion object {
+        private const val ARG_FOLDER_ITEM = "folderItem"
+        private const val ARG_FOLDER_POSITION = "folderPosition"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderDeleteDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderDeleteDialogFragment.kt
@@ -1,0 +1,81 @@
+package com.hyeeyoung.wishboard.view.folder.screens
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.databinding.DialogFolderDeleteBinding
+import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FolderDeleteDialogFragment : DialogFragment() {
+    private lateinit var binding: DialogFolderDeleteBinding
+    private val viewModel: FolderViewModel by activityViewModels()
+    private var folderItem: FolderItem? = null
+    private var position: Int? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DialogFolderDeleteBinding.inflate(inflater, container, false)
+
+        arguments?.let {
+            (it[ARG_FOLDER_ITEM] as? FolderItem)?.let { folder -> folderItem = folder }
+            (it[ARG_FOLDER_POSITION] as? Int)?.let { position -> this.position = position }
+        }
+
+        addListeners()
+        addObservers()
+
+        return binding.root
+    }
+
+    private fun addListeners() {
+        binding.yes.setOnClickListener {
+            viewModel.deleteFolder(folderItem, position)
+        }
+        binding.no.setOnClickListener {
+            dialog?.dismiss()
+        }
+    }
+
+    private fun addObservers() {
+        viewModel.getIsCompleteDeletion().observe(viewLifecycleOwner) { isDeleted ->
+            if (isDeleted) {
+                dismiss()
+                Toast.makeText(
+                    requireContext(),
+                    getString(R.string.folder_delete_toast_text),
+                    Toast.LENGTH_SHORT
+                ).show()
+                viewModel.resetCompleteDeletion()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        dialog?.window?.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        )
+
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+    }
+
+    companion object {
+        private const val TAG = "FolderDeleteDialogFragment"
+        private const val ARG_FOLDER_ITEM = "folderItem"
+        private const val ARG_FOLDER_POSITION = "folderPosition"
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.GridLayoutManager
@@ -20,12 +20,11 @@ import com.hyeeyoung.wishboard.util.loadImage
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
 import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.newFixedThreadPoolContext
 
 @AndroidEntryPoint
 class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener, ImageLoader {
     private lateinit var binding: FragmentFolderBinding
-    private val viewModel: FolderViewModel by viewModels()
+    private val viewModel: FolderViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderMoreDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderMoreDialogFragment.kt
@@ -1,0 +1,60 @@
+package com.hyeeyoung.wishboard.view.folder.screens
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.navigation.fragment.findNavController
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.databinding.DialogFolderMoreBinding
+import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.util.extension.navigateSafe
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FolderMoreDialogFragment : BottomSheetDialogFragment() {
+    private lateinit var binding: DialogFolderMoreBinding
+    private var folderItem: FolderItem? = null
+    private var position: Int? = null
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DialogFolderMoreBinding.inflate(inflater, container, false)
+
+        arguments?.let {
+            (it[ARG_FOLDER_ITEM] as? FolderItem)?.let { folderItem = it }
+            (it[ARG_FOLDER_POSITION] as? Int)?.let { position = it }
+        }
+
+        addListener()
+
+        return binding.root
+    }
+
+    private fun addListener() {
+        binding.update.setOnClickListener {
+            dismiss()
+            TODO("not yet implemented")
+        }
+        binding.delete.setOnClickListener {
+            dismiss()
+            findNavController().navigateSafe(
+                R.id.action_folder_more_to_folder_delete_dialog,
+                bundleOf(
+                    ARG_FOLDER_ITEM to folderItem,
+                    ARG_FOLDER_POSITION to position
+                )
+            )
+        }
+    }
+
+    companion object {
+        private const val TAG = "FolderListFragment"
+        private const val ARG_FOLDER_ITEM = "folderItem"
+        private const val ARG_FOLDER_POSITION = "folderPosition"
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -1,8 +1,11 @@
 package com.hyeeyoung.wishboard.viewmodel
 
 import android.app.Application
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderListViewType
 import com.hyeeyoung.wishboard.repository.folder.FolderRepository
 import com.hyeeyoung.wishboard.util.prefs
@@ -22,6 +25,7 @@ class FolderViewModel @Inject constructor(
         FolderListAdapter(application, FolderListViewType.SQUARE_VIEW_TYPE)
     private val folderListSummaryAdapter =
         FolderListAdapter(application, FolderListViewType.HORIZONTAL_VIEW_TYPE)
+    private var isCompleteDeletion = MutableLiveData<Boolean>()
 
     fun fetchFolderList() {
         if (token == null) return
@@ -39,8 +43,21 @@ class FolderViewModel @Inject constructor(
         }
     }
 
+    fun deleteFolder(folder: FolderItem?, position: Int?) {
+        if (token == null || folder?.id == null) return // TODO 삭제 실패 예외처리 필요
+        viewModelScope.launch {
+            isCompleteDeletion.value = folderRepository.deleteFolder(token, folder.id)
+        }
+        folderListAdapter.deleteData(position ?: return, folder)
+    }
+
+    fun resetCompleteDeletion() {
+        isCompleteDeletion.value = false
+    }
+
     fun getFolderListAdapter(): FolderListAdapter = folderListAdapter
     fun getFolderListSummaryAdapter(): FolderListAdapter = folderListSummaryAdapter
+    fun getIsCompleteDeletion(): LiveData<Boolean> = isCompleteDeletion
 
     companion object {
         private const val TAG = "FolderViewModel"

--- a/app/src/main/res/drawable/background_solid_button.xml
+++ b/app/src/main/res/drawable/background_solid_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="25dp" />
+    <solid android:color="@color/black" />
+    <size android:height="50dp" />
+</shape>

--- a/app/src/main/res/layout/dialog_folder_delete.xml
+++ b/app/src/main/res/layout/dialog_folder_delete.xml
@@ -2,81 +2,91 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="">
+    tools:context="com.hyeeyoung.wishboard.view.folder.screens.FolderDeleteDialogFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:background="@drawable/background_dialog"
-        android:padding="20dp">
+        android:layout_height="match_parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/title_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingVertical="25dp"
+            android:layout_marginHorizontal="20dp"
+            android:background="@drawable/background_dialog"
+            android:padding="20dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
-                android:id="@+id/title"
-                android:layout_width="wrap_content"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/title_container"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/nanum_square_eb"
-                android:text="@string/folder_delete_dialog_title"
-                android:textColor="@color/gray_700"
-                android:textSize="15dp"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:text="@string/folder_delete_dialog_title"
+                    android:textColor="@color/gray_700"
+                    android:textSize="15sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+                <!--        @TODO : 임의로 넣음 강조를 위해서. 워딩 수정 필요-->
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:fontFamily="@font/nanum_square_r"
+                    android:text="@string/folder_delete_dialog_detail"
+                    android:textColor="@color/gray_300"
+                    android:textSize="15sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/title" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="35dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-            <!--        @TODO : 임의로 넣음 강조를 위해서. 워딩 수정 필요-->
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:fontFamily="@font/nanum_square_r"
-                android:text="@string/folder_delete_dialog_detail"
-                android:textColor="@color/gray_300"
-                android:textSize="15dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/title" />
+                app:layout_constraintTop_toBottomOf="@id/title_container">
+
+                <Button
+                    android:id="@+id/no"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_marginEnd="20dp"
+                    android:background="@drawable/background_button_line"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:outlineProvider="none"
+                    android:text="@string/cancel"
+                    android:textColor="@color/gray_700"
+                    android:textSize="15sp"
+                    app:layout_constraintEnd_toStartOf="@id/yes"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <Button
+                    android:id="@+id/yes"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:background="@drawable/background_solid_button"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:outlineProvider="none"
+                    android:text="@string/confirm"
+                    android:textColor="@color/white"
+                    android:textSize="15sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/no"
+                    app:layout_constraintTop_toTopOf="parent" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="20dp"
-            app:layout_constraintTop_toBottomOf="@id/title_container">
-
-            <Button
-                android:id="@+id/cancel"
-                android:layout_width="0dp"
-                android:layout_height="50dp"
-                android:layout_marginRight="20dp"
-                android:layout_weight="1"
-                android:background="@drawable/background_button_line"
-                android:fontFamily="@font/nanum_square_eb"
-                android:onClick="onClick"
-                android:outlineProvider="none"
-                android:text="@string/cancel"
-                android:textColor="@color/gray_700"
-                android:textSize="15dp" />
-
-            <Button
-                android:id="@+id/confirm"
-                android:layout_width="0dp"
-                android:layout_height="50dp"
-                android:layout_weight="1"
-                android:background="@drawable/background_button_green"
-                android:fontFamily="@font/nanum_square_eb"
-                android:onClick="onClick"
-                android:outlineProvider="none"
-                android:text="@string/confirm"
-                android:textColor="@color/gray_700"
-                android:textSize="15dp" />
-        </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/dialog_folder_more.xml
+++ b/app/src/main/res/layout/dialog_folder_more.xml
@@ -2,47 +2,66 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="">
+    tools:context="com.hyeeyoung.wishboard.view.folder.screens.FolderMoreDialogFragment">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@drawable/background_bottom_sheet_dialog"
+        android:background="@drawable/background_dialog_top_corner"
         android:orientation="vertical"
-        android:padding="20dp"
-        tools:ignore="MissingConstraints">
+        android:paddingBottom="20dp">
+
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:fontFamily="@font/nanum_square_eb"
+            android:gravity="center"
+            android:text="@string/folder_more_dialog_title"
+            android:textColor="@color/gray_700"
+            android:textSize="17sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <ImageButton
             android:id="@+id/cancel"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_margin="8dp"
             android:layout_marginBottom="20dp"
             android:background="@android:color/transparent"
-            android:onClick="onClick"
-            android:src="@drawable/ic_delete" />
+            android:padding="@dimen/spacing12"
+            android:src="@drawable/ic_delete"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <TextView
-            android:id="@+id/btn_del"
+            android:id="@+id/delete"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
+            android:layout_marginTop="20dp"
             android:fontFamily="@font/nanum_square_b"
-            android:onClick="onClick"
+            android:gravity="center"
             android:paddingVertical="10dp"
             android:text="@string/folder_delete"
             android:textColor="@color/gray_700"
-            android:textSize="17dp" />
+            android:textSize="15sp"
+            app:layout_constraintTop_toBottomOf="@id/title" />
 
         <TextView
-            android:id="@+id/btn_upt"
+            android:id="@+id/update"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="5dp"
             android:fontFamily="@font/nanum_square_b"
-            android:onClick="onClick"
+            android:gravity="center"
             android:paddingVertical="10dp"
             android:text="@string/folder_name_edit"
             android:textColor="@color/gray_700"
-            android:textSize="17dp" />
+            android:textSize="15sp"
+            app:layout_constraintTop_toBottomOf="@id/delete" />
 
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -42,6 +42,9 @@
             android:id="@+id/action_folder_to_folder_add_dialog"
             app:destination="@id/folderAddDialog" />
         <action
+            android:id="@+id/action_folder_to_folder_more_dialog"
+            app:destination="@id/folderMoreDialog" />
+        <action
             android:id="@+id/action_folder_to_folder_detail"
             app:destination="@id/folderDetailFragment" />
     </fragment>
@@ -75,4 +78,18 @@
         android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderAddDialogFragment"
         android:label="dialog_folder_add"
         tools:layout="@layout/dialog_new_folder_add" />
+    <dialog
+        android:id="@+id/folderMoreDialog"
+        android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderMoreDialogFragment"
+        android:label="dialog_folder_more"
+        tools:layout="@layout/dialog_folder_more">
+        <action
+            android:id="@+id/action_folder_more_to_folder_delete_dialog"
+            app:destination="@id/folderDeleteDialog" />
+    </dialog>
+    <dialog
+        android:id="@+id/folderDeleteDialog"
+        android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderDeleteDialogFragment"
+        android:label="dialog_folder_delete"
+        tools:layout="@layout/dialog_folder_delete" />
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,6 +32,8 @@
     <string name="folder_add_dialog_folder_name_length_format">(%d/10)</string>
     <string name="folder_delete_dialog_title">정말 삭제하시겠습니까?</string>
     <string name="folder_delete_dialog_detail">해당 폴더에 담긴 모든 아이템이 사라질 수 있어요!</string>
+    <string name="folder_delete_toast_text">폴더를 삭제했습니다</string>
+    <string name="folder_more_dialog_title">옵션 더보기</string>
     <string name="folder_delete">폴더 삭제</string>
     <string name="folder_name_edit">폴더명 수정</string>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -5,6 +5,7 @@
         <item name="colorPrimaryDark">@color/black</item>
         <item name="colorAccent">@color/gray_100</item>
         <item name="android:includeFontPadding">false</item>
+        <item name="bottomSheetDialogTheme">@style/BottomSheetDialogStyle</item>
     </style>
 
     <style name="AppThemePopup" parent="AppTheme">
@@ -23,12 +24,11 @@
         <item name="android:fontFamily">@font/nanum_square_b</item>
     </style>
 
-    <!-- TODO MoreFolderDiolog에서 사용될 bottom sheet diolog style, 적용 안됨 -->
-    <style name="CustomBottomSheetDialogTheme" parent="Theme.MaterialComponents.Light.BottomSheetDialog">
-        <item name="bottomSheetStyle">@style/CustomBottomSheetStyle</item>
+    <style name="BottomSheetDialogStyle" parent="Theme.Design.Light.BottomSheetDialog">
+        <item name="bottomSheetStyle">@style/bottomSheetBackground</item>
     </style>
 
-    <style name="CustomBottomSheetStyle" parent="Widget.Design.BottomSheet.Modal">
+    <style name="bottomSheetBackground" parent="Widget.Design.BottomSheet.Modal">
         <item name="android:background">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
## What is this PR? 🔍
폴더 삭제 프로세스와 UI를 구현
## Key Changes 🔑
1. 폴더 삭제 UI 구현
   - 폴더 삭제 절차에 포함된 다이얼로그의 디자인을 일부 수정 및 클릭 시 화면 전환 처리
      - `FolderItem > 더보기 버튼` 클릭 > `옵션 더보기 다이얼로그` 띄우기
      - `옵션 더보기 다이얼로그` > `폴더 삭제 버튼` 클릭 > `폴더 삭제 다이얼로그` 띄우기
   - 폴더 삭제 성공한 경우 `FolderListAdapter`에서 해당 `FolderItem`을 삭제 하면서 UI 업데이트 및 토스트 띄우기

2. 폴더 삭제 프로세스 구현
   - 폴더 삭제 다이얼로그에서 확인 버튼 클릭 시 ViewModel에서 삭제 처리
      - 폴더 삭제를  요청하는 `deleteFolder()` 함수 구현
## To Reviewers 📢
- 폴더 삭제 단계에서 각 화면 전환 시 bundle로 삭제될 아이템의 데이터를 전달함
   -  `FolderListAdapter > 더보기 버튼` 클릭(+bundle) > `옵션 더보기 다이얼로그` (+bundle) > `폴더 삭제 다이얼로그`
   - ViewModel에 삭제 대상인 폴더 데이터를 저장하지 않은 이유 : 삭제 버튼의 확인 버튼을 누르기 전까지 삭제 대상임을 확정지을 수 없기 때문
   - 삭제 처리는 ViewModel에서 합니다!
- 폴더 삭제 시 UI 업데이트를 위해 `FolderDeleteDialogFragment`, `FolderFragment` 두 Fragment 간 데이터 공유해야하므로 `activtiyViewModels()`로 ViewModel을 생성합니다!

- 기본 버튼의 background으로 사용할 `background_solid_button.xml` 리소스를 추가했습니다! 
   - 기본 버튼 : 배경색 있음
   - 서브 버튼 : 배경색없이 테두리만 존재
   - 추후 리팩토링 시서브 버튼 background 리소스인 `background_solid_button.xml`을 추가하고 나머지 backround 리소스는 모두 삭제할 예정입니다!

