### PR TITLE
[feat] 폴더명 수정 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/folder/FolderItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/folder/FolderItem.kt
@@ -9,7 +9,7 @@ data class FolderItem(
     @SerializedName("folder_id")
     val id: Long? = null,
     @SerializedName("folder_name")
-    val name: String,
+    var name: String,
     @SerializedName("folder_thumbnail")
     val thumbnail: String? = null,
     @SerializedName("item_count")

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -95,6 +95,14 @@ interface RemoteService {
         @Body folderItem: FolderItem
     ): Response<RequestResult>
 
+    @FormUrlEncoded
+    @PUT("folder/{folder_id}")
+    suspend fun updateFolderName(
+        @Header("Authorization") token: String,
+        @Path("folder_id") folderId: Long,
+        @Field("folder_name") folderName: String
+    ): Response<RequestResult>
+
     @DELETE("folder/{folder_id}")
     suspend fun deleteFolder(
         @Header("Authorization") token: String,

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
@@ -8,5 +8,6 @@ interface FolderRepository {
     suspend fun fetchFolderListSummary(token: String): List<FolderItem>?
     suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>?
     suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean
+    suspend fun updateFolderName(token: String, folderId: Long, folderName: String): Boolean
     suspend fun deleteFolder(token: String, folderId: Long): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.remote.RemoteService
-import com.hyeeyoung.wishboard.repository.wish.WishRepositoryImpl
 
 class FolderRepositoryImpl : FolderRepository {
     private val api = RemoteService.api
@@ -49,6 +48,21 @@ class FolderRepositoryImpl : FolderRepository {
             Log.d(TAG, "폴더 추가 성공")
         } else {
             Log.e(TAG, "폴더 추가 실패: ${response.code()}")
+        }
+        return response.isSuccessful
+    }
+
+    override suspend fun updateFolderName(
+        token: String,
+        folderId: Long,
+        folderName: String
+    ): Boolean {
+        val response = api.updateFolderName(token, folderId, folderName)
+
+        if (response.isSuccessful) {
+            Log.d(TAG, "폴더명 수정 성공")
+        } else {
+            Log.e(TAG, "폴더명 수정 실패: ${response.code()}")
         }
         return response.isSuccessful
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -101,6 +101,10 @@ class FolderListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+    fun updateData(position: Int, folderItem: FolderItem) {
+        dataSet[position] = folderItem
+        notifyItemChanged(position)
+    }
 
     fun deleteData(position: Int, folderItem: FolderItem) {
         dataSet.remove(folderItem)

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderMoreDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderMoreDialogFragment.kt
@@ -38,7 +38,13 @@ class FolderMoreDialogFragment : BottomSheetDialogFragment() {
     private fun addListener() {
         binding.update.setOnClickListener {
             dismiss()
-            TODO("not yet implemented")
+            findNavController().navigateSafe(
+                R.id.action_folder_more_to_folder_add_dialog,
+                bundleOf(
+                    ARG_FOLDER_ITEM to folderItem,
+                    ARG_FOLDER_POSITION to position
+                )
+            )
         }
         binding.delete.setOnClickListener {
             dismiss()

--- a/app/src/main/res/layout/dialog_new_folder_add.xml
+++ b/app/src/main/res/layout/dialog_new_folder_add.xml
@@ -8,7 +8,7 @@
 
         <variable
             name="viewModel"
-            type="com.hyeeyoung.wishboard.viewmodel.FolderAddDialogViewModel" />
+            type="com.hyeeyoung.wishboard.viewmodel.FolderViewModel" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -47,7 +47,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="20dp"
                 android:fontFamily="@font/nanum_square_eb"
-                android:text="@string/folder_add_dialog_title"
+                android:text="@{viewModel.editMode == true ? @string/folder_add_dialog_folder_name_edit_title : @string/folder_add_dialog_title}"
                 android:textColor="@color/gray_700"
                 android:textSize="15sp"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -121,9 +121,8 @@
                 android:background="@drawable/selector_dialog_yes_button_background"
                 android:enabled="@{viewModel.folderName.length() > 0}"
                 android:fontFamily="@font/nanum_square_eb"
-                android:onClick="@{() -> viewModel.createNewFolder()}"
                 android:outlineProvider="none"
-                android:text="@string/add"
+                android:text="@{viewModel.editMode == true ? @string/edit : @string/add}"
                 android:textColor="@color/selector_dialog_yes_button_text_color"
                 android:textSize="15sp"
                 app:layout_constraintTop_toBottomOf="@id/new_folder_container" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -86,6 +86,9 @@
         <action
             android:id="@+id/action_folder_more_to_folder_delete_dialog"
             app:destination="@id/folderDeleteDialog" />
+        <action
+            android:id="@+id/action_folder_more_to_folder_add_dialog"
+            app:destination="@id/folderAddDialog" />
     </dialog>
     <dialog
         android:id="@+id/folderDeleteDialog"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="complete">완료</string>
     <string name="next">다음</string>
     <string name="add">추가</string>
+    <string name="edit">변경</string>
     <string name="colon">:</string>
 
     <!-- Sign -->
@@ -28,10 +29,12 @@
     <string name="folder">폴더</string>
     <string name="folder_list_title">폴더 목록</string>
     <string name="folder_add_dialog_title">새 폴더 추가</string>
+    <string name="folder_add_dialog_folder_name_edit_title">폴더명 수정</string>
     <string name="folder_add_dialog_detail">새 폴더명을 입력하세요.</string>
     <string name="folder_add_dialog_folder_name_length_format">(%d/10)</string>
     <string name="folder_delete_dialog_title">정말 삭제하시겠습니까?</string>
     <string name="folder_delete_dialog_detail">해당 폴더에 담긴 모든 아이템이 사라질 수 있어요!</string>
+    <string name="folder_name_update_toast_text">폴더명을 수정했습니다</string>
     <string name="folder_delete_toast_text">폴더를 삭제했습니다</string>
     <string name="folder_more_dialog_title">옵션 더보기</string>
     <string name="folder_delete">폴더 삭제</string>


### PR DESCRIPTION
## What is this PR? 🔍
폴더명 수정 프로세스 및 UI 변경
## Key Changes 🔑
1. 폴더명 수정 프로세스 구현
   - 폴더명 수정 요청 `updateFolderName()`함수 추가
 2. 폴더명 수정 UI 변경
    - 기존 `FolderAddDialogFragment`와 동일한 UI를 사용하기 때문에 `EditMode`에 따라 update, add 요청(기존 아이템 수동등록과 비슷한 맥락)

## To Reviewers 📢
- 변경된 폴더명을 적용해서 UI를 업데이트하기 위해 `ForderItem`의 `name`프로퍼티를 `val -> var`로 변수선언 수정
- `FolderAddDialogFragment.kt` 전반적인 리팩토링이 필요하고, 사용되지 않는 뷰모델 삭제 필요
   - 파일명 수정 고려 중입니다!
