### PR TITLE
[fix] 장바구니화면에서 totalPrice가 변경되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
@@ -39,7 +39,6 @@ class CartListAdapter(
 
                 delete.setOnClickListener {
                     listener.onItemClick(item, position, CartItemButtonType.VIEW_TYPE_DELETION)
-                    removeItem(position)
                 }
                 container.setOnClickListener {
                     listener.onItemClick(item, position, CartItemButtonType.VIEW_TYPE_CONTAINER)
@@ -71,6 +70,8 @@ class CartListAdapter(
     }
 
     override fun getItemCount(): Int = dataSet.size
+
+    fun getData(): List<CartItem> = dataSet
 
     fun setData(items: List<CartItem>) {
         dataSet.clear()

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/screens/CartFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/screens/CartFragment.kt
@@ -66,7 +66,7 @@ class CartFragment : Fragment(), CartListAdapter.OnItemClickListener, ImageLoade
                 )
             }
             CartItemButtonType.VIEW_TYPE_DELETION -> {
-                viewModel.removeToCart(item.wishItem.id!!)
+                viewModel.removeToCart(item.wishItem.id!!, position)
             }
             CartItemButtonType.VIEW_TYPE_PLUS, CartItemButtonType.VIEW_TYPE_MINUS -> {
                 viewModel.controlItemCount(item, position, viewType)


### PR DESCRIPTION
## What is this PR? 🔍
장바구니화면에서 totalPrice가 변경되지 않는 버그 수정
## Key Changes 🔑
1. `totalPrice = MutableLiveData<Int>()` ->  `totalPrice = MediatorLiveData<Int>()`로 변경
   - `totalPrice.addSource(cartList) { ... }` : **cartList**를 관찰하여 변경될 때 마다 **totalPrice** 를 계산
   - 기존 코드 상에서는 **cartList**가 변경될 때마다 **calculateTotalPrice()** 을 직접 호출해서 가격이 갱신되도록 처리했었는데 아이템 fetch 성공 후 **calculateTotalPrice()** 를 호출하지 않아 가격이 갱신되지 않았던 것이었음
2. **CartItem** 삭제 성공 후 **CartAdapter.dataset**에서 해당 아이템 삭제하도록 변경
   - 기존에 삭제 성공 여부 상관 없이 **dataset**에서 바로 제거

## To Reviewers 📢
- **MediatorLiveData**를 사용하면 하나의 **LiveData**가 하나 이상을 관찰하게 할 수 있습니다.
