### PR TITLE
[feat] 폴더 추가 시 ui 업데이트 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/RequestResultId.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/RequestResultId.kt
@@ -1,0 +1,10 @@
+package com.hyeeyoung.wishboard.model
+
+import com.google.gson.annotations.SerializedName
+
+data class RequestResultId(
+    val success: Boolean,
+    val message: String,
+    @SerializedName("data")
+    val id: Long,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/RequestResultToken.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/RequestResultToken.kt
@@ -3,5 +3,5 @@ package com.hyeeyoung.wishboard.model
 data class RequestResultToken(
     val success: Boolean,
     val message: String,
-    val token: String,
+    val data: String,
 )

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/RequestResultToken.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/RequestResultToken.kt
@@ -1,7 +1,10 @@
 package com.hyeeyoung.wishboard.model
 
+import com.google.gson.annotations.SerializedName
+
 data class RequestResultToken(
     val success: Boolean,
     val message: String,
-    val data: String,
+    @SerializedName("data")
+    val token: String,
 )

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -2,6 +2,7 @@ package com.hyeeyoung.wishboard.remote
 
 import com.hyeeyoung.wishboard.BuildConfig
 import com.hyeeyoung.wishboard.model.RequestResult
+import com.hyeeyoung.wishboard.model.RequestResultId
 import com.hyeeyoung.wishboard.model.RequestResultToken
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.folder.FolderItem
@@ -93,7 +94,7 @@ interface RemoteService {
     suspend fun createNewFolder(
         @Header("Authorization") token: String,
         @Body folderItem: FolderItem
-    ): Response<RequestResult>
+    ): Response<RequestResultId>
 
     @FormUrlEncoded
     @PUT("folder/{folder_id}")

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepository.kt
@@ -7,7 +7,7 @@ interface FolderRepository {
     suspend fun fetchFolderList(token: String): List<FolderItem>?
     suspend fun fetchFolderListSummary(token: String): List<FolderItem>?
     suspend fun fetchItemsInFolder(token: String, folderId: Long): List<WishItem>?
-    suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean
+    suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Long?
     suspend fun updateFolderName(token: String, folderId: Long, folderName: String): Boolean
     suspend fun deleteFolder(token: String, folderId: Long): Boolean
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/folder/FolderRepositoryImpl.kt
@@ -41,7 +41,7 @@ class FolderRepositoryImpl : FolderRepository {
         return response.body()
     }
 
-    override suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Boolean {
+    override suspend fun createNewFolder(token: String, folderItemInfo: FolderItem): Long? {
         val response = api.createNewFolder(token, folderItemInfo)
 
         if (response.isSuccessful) {
@@ -49,7 +49,7 @@ class FolderRepositoryImpl : FolderRepository {
         } else {
             Log.e(TAG, "폴더 추가 실패: ${response.code()}")
         }
-        return response.isSuccessful
+        return response.body()?.id
     }
 
     override suspend fun updateFolderName(

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
@@ -14,7 +14,7 @@ class SignRepositoryImpl : SignRepository {
         //TODO 네트워크에 연결되지 않은 경우 예외처리 필요
         if (response.isSuccessful) {
             Log.d(TAG, "회원가입 성공")
-            result?.token?.let {
+            result?.data?.let {
                 prefs?.setUserInfo(it, email)
             }
         } else {
@@ -28,7 +28,7 @@ class SignRepositoryImpl : SignRepository {
         val result = response.body()
         if (response.isSuccessful) {
             Log.d(TAG, "로그인 성공")
-            result?.token?.let { prefs?.setUserInfo(it, email) }
+            result?.data?.let { prefs?.setUserInfo(it, email) }
         } else {
             Log.e(TAG, "로그인 실패: ${response.code()}")
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
@@ -14,7 +14,7 @@ class SignRepositoryImpl : SignRepository {
         //TODO 네트워크에 연결되지 않은 경우 예외처리 필요
         if (response.isSuccessful) {
             Log.d(TAG, "회원가입 성공")
-            result?.data?.let {
+            result?.token?.let {
                 prefs?.setUserInfo(it, email)
             }
         } else {
@@ -28,7 +28,7 @@ class SignRepositoryImpl : SignRepository {
         val result = response.body()
         if (response.isSuccessful) {
             Log.d(TAG, "로그인 성공")
-            result?.data?.let { prefs?.setUserInfo(it, email) }
+            result?.token?.let { prefs?.setUserInfo(it, email) }
         } else {
             Log.e(TAG, "로그인 실패: ${response.code()}")
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -101,6 +101,11 @@ class FolderListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+    fun addData(folderItem: FolderItem) {
+        dataSet.add(0, folderItem)
+        notifyItemInserted(0)
+    }
+
     fun updateData(position: Int, folderItem: FolderItem) {
         dataSet[position] = folderItem
         notifyItemChanged(position)

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderAddDialogViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderAddDialogViewModel.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class FolderAddDialogViewModel @Inject constructor(
+class FolderAddDialogViewModel @Inject constructor( // TODO 사용되지 않는 파일, 삭제 예정
     private val folderRepository: FolderRepository,
 ) : ViewModel() {
     private val token = prefs?.getUserToken()
@@ -28,7 +28,7 @@ class FolderAddDialogViewModel @Inject constructor(
 
         viewModelScope.launch {
             folderItem = folderInfo
-            isCompleteAddition.value = folderRepository.createNewFolder(token, folderInfo)
+          //  isCompleteAddition.value = folderRepository.createNewFolder(token, folderInfo)
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -55,7 +55,9 @@ class FolderViewModel @Inject constructor(
 
         viewModelScope.launch {
             folderItem = folderInfo
-            isCompleteAddition.value = folderRepository.createNewFolder(token, folderInfo)
+            val folderId = folderRepository.createNewFolder(token, folderInfo) ?: return@launch
+            folderListAdapter.addData(FolderItem(folderId, folderName))
+            isCompleteAddition.value = true
         }
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
폴더 추가 시 서버에서 결과값으로 id값을 보내주는 것으로 수정함에 따라 `RequestResult`관련 dataClass를 수정했고, id값을 받아서 폴더 추가 시 UI가 업데이트 되도록 구현
## Key Changes 🔑
1. `RequestResultId` 데이터 클래스 추가 및 `RequestResultToken`에서 `@SerializedName("data")` 추가
   - 원래 `RequestResultId`와 `RequestResultToken`을 하나의 클래스로 사용하고 싶었으나 data의 데이터 타입이 다음과 같이 구분되어 합칠 수 없었음
   -  token값을 전달 받을 경우 : **String**
   - id값을 전달 받을 경우 : **Long**
2. 폴더 추가 시 전달 받은 폴더 id값 + 폴더명으로 `FolderItem`을 생성해서 `adapter.dataset`에 추가하여 UI를 업데이트
   - 폴더 추가 후 해당 폴더 폴더명 수정도 가능

## To Reviewers 📢
- 서버에서는 RequestResult로 data를 지금과 같이 보내줘도 괜찮을 것 같습니다! 안드에서 data를 사용맥락에 맞춰서 `@SerializedName("..")`을 사용하여 프로퍼티명을 바꾸겠습니다!!