### PR TITLE
[fix] 폴더 추가 후 또 다른 폴더를 추가할 경우 폴더가 추가되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -29,7 +29,7 @@ class FolderViewModel @Inject constructor(
     private var folderItem: FolderItem? = null
     private var isCompleteUpload = MutableLiveData<Boolean>()
     private var isCompleteDeletion = MutableLiveData<Boolean>()
-    private var isEditMode = MutableLiveData<Boolean>()
+    private var isEditMode = MutableLiveData(false)
 
     fun fetchFolderList() {
         if (token == null) return


### PR DESCRIPTION
## What is this PR? 🔍
폴더 추가 후 또 다른 폴더 추가 시 새폴더가 생성되지 않는 버그를 수정
## Key Changes 🔑
1. FolderViewModel.kt에서 isEditMode의 초깃값을 null -> false로 설정
   - 원인 : 폴더 수정을 한번도 하지 않았을 때, 폴더 추가 후 또 다른 폴더 추가할 경우 isEditMode 가 null 값이면 `viewModel.createNewFolder()`이 호출되지 않아 새폴더가 생성되지 않았던 것임
```kotlin
// FolderAddDialogFragment.kt
 binding.add.setOnClickListener {
            when (viewModel.getEditMode().value) {
                true -> viewModel.updateFolderName(folderItem, position)
                false -> viewModel.createNewFolder() // false일 때만 실행
            }
        }
```