### PR TITLE
[refactor] 폴더 추가 및 폴더명 수정을 구분하는 isEditMode 설정 관련 코드 리팩토링

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
@@ -31,9 +31,16 @@ class FolderAddDialogFragment : DialogFragment() {
         binding.viewModel = viewModel
         binding.lifecycleOwner = this@FolderAddDialogFragment
 
-        arguments?.let {
+        viewModel.resetFolderData()
+
+        arguments.let {
+            if (it == null) {
+                viewModel.setEditMode(false)
+                return@let
+            }
+
+            viewModel.setEditMode(true)
             (it[ARG_FOLDER_ITEM] as? FolderItem)?.let { folder ->
-                viewModel.setEditMode(true)
                 folderItem = folder
                 viewModel.setFolderName(folder.name)
             }
@@ -60,7 +67,7 @@ class FolderAddDialogFragment : DialogFragment() {
 
     private fun addObservers() {
         viewModel.getIsCompleteUpload().observe(viewLifecycleOwner) { isComplete ->
-            if (isComplete) {
+            if (isComplete == true) {
                 dismiss()
                 val toastMessageRes = when (viewModel.getEditMode().value) {
                     true -> R.string.folder_name_update_toast_text
@@ -68,8 +75,6 @@ class FolderAddDialogFragment : DialogFragment() {
                 }
                 Toast.makeText(requireContext(), getString(toastMessageRes), Toast.LENGTH_SHORT)
                     .show()
-
-                viewModel.resetFolderData()
             }
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -29,8 +29,8 @@ class FolderViewModel @Inject constructor(
     private var folderItem: FolderItem? = null
     private var isCompleteUpload = MutableLiveData<Boolean>()
     private var isCompleteDeletion = MutableLiveData<Boolean>()
-    private var isEditMode = MutableLiveData(false)
     private var isExistFolderName = MutableLiveData<Boolean>()
+    private var isEditMode = MutableLiveData<Boolean>()
 
     fun fetchFolderList() {
         if (token == null) return
@@ -93,8 +93,8 @@ class FolderViewModel @Inject constructor(
     /** 폴더 추가 후 또 다른 폴더 추가/수정을 위해 이전에 입력한 폴더명 등의 폴더 관련 데이터를 reset */
     fun resetFolderData() {
         folderName.value = null
-        isEditMode.value = false
-        isCompleteUpload.value = false
+        isCompleteUpload.value = null
+        isExistFolderName.value = null
     }
 
     fun resetCompleteDeletion() {


### PR DESCRIPTION
## What is this PR? 🔍
폴더 추가 및 폴더명 수정을 구분하는 `isEditMode` 설정 관련 코드 리팩토링함
## Key Changes 🔑
1. `FolderAddDialogFragment.kt`에서 arguments 존재 여부에 따라 `isEditMode` 를 설정
2. `FolderAddDialogFragment.kt` 진입 즉, 다이얼로그 띄울 때 폴더 업로드 관련 데이터를 reset하는 `resetFolderData()` 호출