### PR TITLE
아이템 업로드 및 장바구니화면에서 가격 포맷 적용

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -20,7 +20,6 @@ import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.util.ImageLoader
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.loadImage
-import com.hyeeyoung.wishboard.view.folder.screens.FolderListFragment
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -42,7 +41,7 @@ class WishBasicFragment : Fragment(), ImageLoader {
     ): View {
         binding = FragmentWishBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
-
+        binding.lifecycleOwner = this@WishBasicFragment
 
         // 갤러리 이미지 선택 화면으로 전환 -> 해당 화면 복귀할 경우, 생명주기상 onCreateView를 재호출되고,
         // if문 내 코드를 실행하면서 입력된 정보가 reset되는 문제가 있음

--- a/app/src/main/res/layout/activity_wish_link_sharing.xml
+++ b/app/src/main/res/layout/activity_wish_link_sharing.xml
@@ -90,7 +90,8 @@
                             android:textAlignment="center"
                             android:textColor="@color/black"
                             android:textColorHint="@color/gray_300"
-                            android:textSize="15sp" />
+                            android:textSize="15sp"
+                            android:selection="@{viewModel.itemPrice.length()}" />
 
                         <!-- @brief : 원 표시 추가할지 고민 중-->
                         <!--                <TextView-->

--- a/app/src/main/res/layout/fragment_cart.xml
+++ b/app/src/main/res/layout/fragment_cart.xml
@@ -105,11 +105,11 @@
                 android:layout_marginRight="2dp"
                 android:layout_toLeftOf="@id/won"
                 android:fontFamily="@font/nanum_square_eb"
-                android:text="@{Integer.toString(viewModel.totalPrice)}"
                 android:textColor="@color/gray_700"
                 android:textSize="17dp"
                 app:layout_constraintEnd_toStartOf="@id/won"
                 app:layout_constraintTop_toTopOf="parent"
+                app:priceFormat="@{viewModel.totalPrice}"
                 tools:text="0" />
 
             <TextView

--- a/app/src/main/res/layout/fragment_wish.xml
+++ b/app/src/main/res/layout/fragment_wish.xml
@@ -191,6 +191,7 @@
                             android:textColor="@color/gray_700"
                             android:textSize="13dp" />
 
+                        <!-- text, selection 순서 바뀌지 않도록 주의 -->
                         <EditText
                             android:id="@+id/item_price"
                             android:layout_width="0dp"
@@ -206,7 +207,8 @@
                             android:text="@{viewModel.itemPrice}"
                             android:textColor="@color/gray_700"
                             android:textColorHint="@color/gray_200"
-                            android:textSize="13dp" />
+                            android:textSize="13sp"
+                            android:selection="@{viewModel.itemPrice.length()}" />
                     </LinearLayout>
 
                     <LinearLayout


### PR DESCRIPTION
## What is this PR? 🔍
아이템 업로드 및 장바구니화면에서 가격 포맷 적용
## Key Changes 🔑
1. 아이템 등록 및 수정 시 가격 EditText에 천단위 구분자를 적용
   - EditText 이기 때문에 xml에서 바로 priceFormat 적용 어려움, viewModel에서 처리
2. 장바구니 하단 totalPrice에 TextView에 천단위 구분자를 적용

## To Reviewers 📢
- DB에는 구분자 없이 number 타입 그대로 저장됩니다
   - view : 130,000
   - db : 130000 
- `android:selection="@{viewModel.itemPrice.length()}"`: price EditText에서 가격 변경 시 마다 커서가 제일 앞으로 이동하기 때문에 맨뒤로 옮겨야함. -> 커서가 앞에 있으면 가격이 30,000원 일때 1을 입력할 경우, 130,000 이 되버림
- text, selection 순을 유지해야함 그렇지 않을 경우, `IndexOutOfBoundsException: setSpan ~~ ends beyond length ~` 에러 발생
   - 실행 순서에 따른 에러로 파악 : text 가 먼저 지정된 후 해당 text의 length를 받아와야 IndexOutOfBoundsException 을 방지할 수 있음
   - 해당 부분을 해결하기위해 많은 시간 소모됨 🥲
   - 코드 리포맷 적용 시 text와 selection 순서 뒤바뀜 주의
- xml에서 일부 TextSize 속성값을 dp -> sp로 변경 필요합니다. 이슈 추가후 작업 예정
- ci 실패는 해당 PR과는 관련 없음
   -  알림 관련 환경변수 키를 찾지 못해 발생하는 에러로 머지되면 해결될 것으로 파악