### PR TITLE
[fix] 폴더 지정 버그 및 폴더 수정 및 삭제 다이얼로그 전환 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
@@ -32,7 +32,6 @@ class FolderAddDialogFragment : DialogFragment() {
         binding.lifecycleOwner = this@FolderAddDialogFragment
 
         viewModel.resetFolderData()
-
         arguments.let {
             if (it == null) {
                 viewModel.setEditMode(false)
@@ -61,7 +60,7 @@ class FolderAddDialogFragment : DialogFragment() {
             }
         }
         binding.close.setOnClickListener {
-            dialog?.dismiss()
+            dismiss()
         }
     }
 
@@ -85,12 +84,11 @@ class FolderAddDialogFragment : DialogFragment() {
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
         )
-
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     }
 
     companion object {
-        private const val TAG = "FolderAdditionDialogFragment"
+        const val TAG = "FolderAdditionDialogFragment"
         private const val ARG_FOLDER_ITEM = "folderItem"
         private const val ARG_FOLDER_POSITION = "folderPosition"
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderDeleteDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderDeleteDialogFragment.kt
@@ -69,12 +69,11 @@ class FolderDeleteDialogFragment : DialogFragment() {
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.MATCH_PARENT
         )
-
         dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
     }
 
     companion object {
-        private const val TAG = "FolderDeleteDialogFragment"
+        const val TAG = "FolderDeleteDialogFragment"
         private const val ARG_FOLDER_ITEM = "folderItem"
         private const val ARG_FOLDER_POSITION = "folderPosition"
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -33,8 +33,6 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener, ImageL
         binding = FragmentFolderBinding.inflate(inflater, container, false)
         binding.viewModel = viewModel
 
-        viewModel.fetchFolderList()
-
         initializeView()
         addListeners()
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
@@ -6,31 +6,29 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.fragment.app.viewModels
+import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentFolderListBinding
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.util.ImageLoader
 import com.hyeeyoung.wishboard.util.loadImage
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
-import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
+import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener, ImageLoader {
     private lateinit var binding: FragmentFolderListBinding
-    private val viewModel: FolderViewModel by viewModels()
+    private val viewModel: WishItemRegistrationViewModel by hiltNavGraphViewModels(R.id.wish_item_registration_nav_graph)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentFolderListBinding.inflate(inflater, container, false)
-        binding.viewModel = viewModel
-
-        viewModel.fetchFolderListSummary()
 
         initializeView()
 
@@ -38,7 +36,7 @@ class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener, Im
     }
 
     private fun initializeView() {
-        val adapter = viewModel.getFolderListSummaryAdapter()
+        val adapter = viewModel.getFolderListAdapter()
         adapter.setOnItemClickListener(this)
         adapter.setImageLoader(this)
         binding.folderList.adapter = adapter
@@ -46,10 +44,8 @@ class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener, Im
     }
 
     override fun onItemClick(item: FolderItem) {
-        findNavController().apply {
-            previousBackStackEntry?.savedStateHandle?.set(ARG_FOLDER_ITEM, item)
-            popBackStack()
-        }
+        viewModel.setFolderItem(item)
+        findNavController().popBackStack()
     }
 
     override fun loadImage(imageUrl: String, imageView: ImageView) {
@@ -58,6 +54,5 @@ class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener, Im
 
     companion object {
         private const val TAG = "FolderListFragment"
-        private const val ARG_FOLDER_ITEM = "folderItem"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderMoreDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderMoreDialogFragment.kt
@@ -4,31 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.core.os.bundleOf
-import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.DialogFolderMoreBinding
-import com.hyeeyoung.wishboard.model.folder.FolderItem
-import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class FolderMoreDialogFragment : BottomSheetDialogFragment() {
     private lateinit var binding: DialogFolderMoreBinding
-    private var folderItem: FolderItem? = null
-    private var position: Int? = null
+    private var folderInfo: Bundle? = null
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         binding = DialogFolderMoreBinding.inflate(inflater, container, false)
-
-        arguments?.let {
-            (it[ARG_FOLDER_ITEM] as? FolderItem)?.let { folderItem = it }
-            (it[ARG_FOLDER_POSITION] as? Int)?.let { position = it }
-        }
+        folderInfo = arguments
 
         addListener()
 
@@ -37,30 +27,20 @@ class FolderMoreDialogFragment : BottomSheetDialogFragment() {
 
     private fun addListener() {
         binding.update.setOnClickListener {
-            dismiss()
-            findNavController().navigateSafe(
-                R.id.action_folder_more_to_folder_add_dialog,
-                bundleOf(
-                    ARG_FOLDER_ITEM to folderItem,
-                    ARG_FOLDER_POSITION to position
-                )
-            )
+            dialog?.dismiss()
+            val dialog = FolderAddDialogFragment()
+            dialog.arguments = folderInfo
+            dialog.show(requireActivity().supportFragmentManager, FolderAddDialogFragment.TAG)
         }
         binding.delete.setOnClickListener {
-            dismiss()
-            findNavController().navigateSafe(
-                R.id.action_folder_more_to_folder_delete_dialog,
-                bundleOf(
-                    ARG_FOLDER_ITEM to folderItem,
-                    ARG_FOLDER_POSITION to position
-                )
-            )
+            dialog?.dismiss()
+            val dialog = FolderDeleteDialogFragment()
+            dialog.arguments = folderInfo
+            dialog.show(requireActivity().supportFragmentManager, FolderDeleteDialogFragment.TAG)
         }
     }
 
     companion object {
-        private const val TAG = "FolderListFragment"
-        private const val ARG_FOLDER_ITEM = "folderItem"
-        private const val ARG_FOLDER_POSITION = "folderPosition"
+        private const val TAG = "FolderMoreDialogFragment"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -15,7 +15,6 @@ import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
-import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.util.ImageLoader
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
@@ -126,13 +125,6 @@ class WishBasicFragment : Fragment(), ImageLoader {
                 Glide.with(requireContext()).load(uri).into(binding.itemImage)
             }
         }
-
-        // 폴더 리스트에서 선택한 폴더 정보를 전달받음
-        findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<FolderItem>(
-            ARG_FOLDER_ITEM
-        )?.observe(viewLifecycleOwner) { folder ->
-            viewModel.setFolderItem(folder)
-        }
     }
 
     private val requestStorage =
@@ -151,6 +143,5 @@ class WishBasicFragment : Fragment(), ImageLoader {
         private const val TAG = "WishBasicFragment"
         private const val ARG_WISH_ITEM = "wishItem"
         private const val ARG_IS_EDIT_MODE = "isEditMode"
-        private const val ARG_FOLDER_ITEM = "folderItem"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -23,8 +23,6 @@ class FolderViewModel @Inject constructor(
 
     private val folderListAdapter =
         FolderListAdapter(application, FolderListViewType.SQUARE_VIEW_TYPE)
-    private val folderListSummaryAdapter =
-        FolderListAdapter(application, FolderListViewType.HORIZONTAL_VIEW_TYPE)
     private var folderName = MutableLiveData<String>()
     private var folderItem: FolderItem? = null
     private var isCompleteUpload = MutableLiveData<Boolean>()
@@ -32,19 +30,14 @@ class FolderViewModel @Inject constructor(
     private var isExistFolderName = MutableLiveData<Boolean>()
     private var isEditMode = MutableLiveData<Boolean>()
 
+    init {
+        fetchFolderList()
+    }
+
     fun fetchFolderList() {
         if (token == null) return
         viewModelScope.launch {
             folderListAdapter.setData(folderRepository.fetchFolderList(token) ?: return@launch)
-        }
-    }
-
-    fun fetchFolderListSummary() {
-        if (token == null) return
-        viewModelScope.launch {
-            folderListSummaryAdapter.setData(
-                folderRepository.fetchFolderListSummary(token) ?: return@launch
-            )
         }
     }
 
@@ -110,7 +103,6 @@ class FolderViewModel @Inject constructor(
     }
 
     fun getFolderListAdapter(): FolderListAdapter = folderListAdapter
-    fun getFolderListSummaryAdapter(): FolderListAdapter = folderListSummaryAdapter
     fun getFolderName(): LiveData<String> = folderName
     fun getIsCompleteUpload(): LiveData<Boolean> = isCompleteUpload
     fun getIsCompleteDeletion(): LiveData<Boolean> = isCompleteDeletion

--- a/app/src/main/res/layout/dialog_new_folder_add.xml
+++ b/app/src/main/res/layout/dialog_new_folder_add.xml
@@ -22,10 +22,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginHorizontal="20dp"
+            android:layout_marginHorizontal="10dp"
             android:background="@drawable/background_dialog"
-            android:paddingStart="20dp"
-            android:paddingBottom="20dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -54,93 +52,100 @@
                 android:textSize="15sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="새 폴더 추가" />
 
             <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/folder_name_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginEnd="20dp"
-                app:layout_constraintTop_toBottomOf="@id/title">
+                android:padding="20dp"
+                app:layout_constraintTop_toBottomOf="@id/close">
 
-                <!-- TODO 폴더 이미지 삭제 고려 중 -->
-                <!--                <de.hdodenhof.circleimageview.CircleImageView-->
-                <!--                    android:id="@+id/folder_image"-->
-                <!--                    android:layout_width="40dp"-->
-                <!--                    android:layout_height="40dp"-->
-                <!--                    android:src="@mipmap/ic_main"-->
-                <!--                    app:layout_constraintStart_toStartOf="parent"-->
-                <!--                    app:layout_constraintTop_toTopOf="parent" />-->
-
-                <EditText
-                    android:id="@+id/folder_name"
-                    android:layout_width="0dp"
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:id="@+id/folder_name_container"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="@dimen/spacing12"
-                    android:background="@null"
-                    android:fontFamily="@font/nanum_square_b"
-                    android:hint="@string/folder_add_dialog_detail"
-                    android:maxLength="10"
-                    android:onTextChanged="@{viewModel::onFolderNameTextChanged}"
-                    android:paddingVertical="@dimen/spacing12"
-                    android:text="@{viewModel.folderName}"
-                    android:textColor="@color/gray_700"
-                    android:textSize="15sp"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/folder_name_length"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="새 폴더" />
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <!-- TODO 폴더 이미지 삭제 고려 중 -->
+                    <!--                <de.hdodenhof.circleimageview.CircleImageView-->
+                    <!--                    android:id="@+id/folder_image"-->
+                    <!--                    android:layout_width="40dp"-->
+                    <!--                    android:layout_height="40dp"-->
+                    <!--                    android:src="@mipmap/ic_main"-->
+                    <!--                    app:layout_constraintStart_toStartOf="parent"-->
+                    <!--                    app:layout_constraintTop_toTopOf="parent" />-->
+
+                    <EditText
+                        android:id="@+id/folder_name"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="@dimen/spacing12"
+                        android:background="@null"
+                        android:fontFamily="@font/nanum_square_b"
+                        android:hint="@string/folder_add_dialog_detail"
+                        android:maxLength="10"
+                        android:onTextChanged="@{viewModel::onFolderNameTextChanged}"
+                        android:paddingVertical="@dimen/spacing12"
+                        android:text="@{viewModel.folderName}"
+                        android:textColor="@color/gray_700"
+                        android:textSize="15sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/folder_name_length"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="새 폴더" />
+
+                    <TextView
+                        android:id="@+id/folder_name_length"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/nanum_square_r"
+                        android:maxLength="10"
+                        android:text="@{String.format(@string/folder_add_dialog_folder_name_length_format, viewModel.folderName.length())}"
+                        android:textColor="@color/gray_700"
+                        android:textSize="15sp"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="7/10글자" />
+
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:background="@color/black"
+                        app:layout_constraintBottom_toBottomOf="parent" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
-                    android:id="@+id/folder_name_length"
+                    android:id="@+id/folder_name_detail_text"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
                     android:fontFamily="@font/nanum_square_r"
-                    android:maxLength="10"
-                    android:text="@{String.format(@string/folder_add_dialog_folder_name_length_format, viewModel.folderName.length())}"
-                    android:textColor="@color/gray_700"
+                    android:text="@string/folder_name_already_exist_toast_text"
+                    android:textColor="@color/green_700"
+                    android:textSize="12sp"
+                    android:visibility="@{viewModel.isExistFolderName == true ? View.VISIBLE : View.INVISIBLE}"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/folder_name_container" />
+
+                <Button
+                    android:id="@+id/add"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_marginTop="20dp"
+                    android:background="@drawable/selector_dialog_yes_button_background"
+                    android:enabled="@{viewModel.folderName.length() > 0}"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:outlineProvider="none"
+                    android:text="@{viewModel.editMode == true ? @string/edit : @string/add}"
+                    android:textColor="@color/selector_dialog_yes_button_text_color"
                     android:textSize="15sp"
-                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:text="7/10글자" />
-
-                <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/black"
-                    app:layout_constraintBottom_toBottomOf="parent" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/folder_name_detail_text" />
             </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <TextView
-                android:id="@+id/folder_name_detail_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="5dp"
-                android:fontFamily="@font/nanum_square_r"
-                android:text="@string/folder_name_already_exist_toast_text"
-                android:textColor="@color/green_700"
-                android:textSize="12sp"
-                android:visibility="@{viewModel.isExistFolderName == true ? View.VISIBLE : View.INVISIBLE}"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/folder_name_container" />
-
-            <Button
-                android:id="@+id/add"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:layout_marginTop="20dp"
-                android:layout_marginEnd="20dp"
-                android:background="@drawable/selector_dialog_yes_button_background"
-                android:enabled="@{viewModel.folderName.length() > 0}"
-                android:fontFamily="@font/nanum_square_eb"
-                android:outlineProvider="none"
-                android:text="@{viewModel.editMode == true ? @string/edit : @string/add}"
-                android:textColor="@color/selector_dialog_yes_button_text_color"
-                android:textSize="15sp"
-                app:layout_constraintTop_toBottomOf="@id/folder_name_detail_text" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_folder_list.xml
+++ b/app/src/main/res/layout/fragment_folder_list.xml
@@ -7,10 +7,6 @@
     <data>
 
         <import type="androidx.navigation.Navigation" />
-
-        <variable
-            name="viewModel"
-            type="com.hyeeyoung.wishboard.viewmodel.FolderViewModel" />
     </data>
 
     <LinearLayout

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -82,17 +82,5 @@
         android:id="@+id/folderMoreDialog"
         android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderMoreDialogFragment"
         android:label="dialog_folder_more"
-        tools:layout="@layout/dialog_folder_more">
-        <action
-            android:id="@+id/action_folder_more_to_folder_delete_dialog"
-            app:destination="@id/folderDeleteDialog" />
-        <action
-            android:id="@+id/action_folder_more_to_folder_add_dialog"
-            app:destination="@id/folderAddDialog" />
-    </dialog>
-    <dialog
-        android:id="@+id/folderDeleteDialog"
-        android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderDeleteDialogFragment"
-        android:label="dialog_folder_delete"
-        tools:layout="@layout/dialog_folder_delete" />
+        tools:layout="@layout/dialog_folder_more"/>
 </navigation>


### PR DESCRIPTION
## What is this PR? 🔍
아이템 업로드 시 폴더가 한번에 지정되지 않는 버그와 폴더 더보기에서 폴더명 수정 및 폴더 삭제 다이얼로그로 전환되지 않는 버그를 수정
## Key Changes 🔑
1. 폴더가 한번에 지정되지 않는 버그 수정
   - 원인 : 폴더 지정 후 아이템 업로드 화면으로 복귀 시 `bundle`로 폴더 정보를 전달하는 과정에서 처음 폴더를 지정할 경우 null이 전달되었음
   - 해결 : 폴더 정보를 `bundle`로 전달하지 않고, `WishItemRegistrationViewModel.kt`에 바로 폴더 정보를 저장하는 방식으로 변경
      - `FolderViewModel.kt`에서 `fetchFolderListSummary()`를 `WishItemRegistrationViewModel.kt`로 옮기고 함수명을 `fetchFolderList()`로 변경

2. 폴더 더보기에서 폴더명 수정 및 폴더 삭제 다이얼로그로 전환되지 않는 버그 수정 
   - gradle 및 각종 라이브러리 버전을 업그레이드 하면서 해당 버그가 발생
   - 폴더 더보기 다이얼로그에서 dismiss 후 폴더명 수정 및 폴더 삭제 다이얼로그로 이동했을 때 해당 다이얼로그도 바로 dismiss 되었던 것이 원인
   - 전환 시 navigation을 사용하지 않고 dialog.show()를 명시적으로 호출하여 `FolderAddDialogFramgent.kt`와 `FolderDeleteDialogFramgent.kt`로 전환하도록 수정

## To Reviewers 📢
- 폴더 추가 및 삭제 다이얼로그가 잘 뜨는지 확인 부탁합니다!
- 아이템 등록 시 폴더가 잘 지정되는지도 확인 부탁해요!
- gradle 버전과 라이브러리 버전을 업그레이드 하면서 `dialog_new_folder_add.xml` 레이아웃이 깨져보여서 수정했습니다! 원상 복구 작업으로 변경사항은 없으니 가볍게 봐주시면 될 것 같습니다!