### PR TITLE
[fix] 장바구니 아이템 깜박임 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
@@ -3,6 +3,8 @@ package com.hyeeyoung.wishboard.view.cart.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hyeeyoung.wishboard.databinding.ItemCartBinding
 import com.hyeeyoung.wishboard.model.cart.CartItem
@@ -11,10 +13,14 @@ import com.hyeeyoung.wishboard.util.ImageLoader
 
 class CartListAdapter(
     private val context: Context
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : ListAdapter<CartItem, RecyclerView.ViewHolder>(diffCallback) {
     private val dataSet = arrayListOf<CartItem>()
     private lateinit var listener: OnItemClickListener
     private lateinit var imageLoader: ImageLoader
+
+    init {
+        setHasStableIds(true)
+    }
 
     interface OnItemClickListener {
         fun onItemClick(item: CartItem, position: Int, viewType: CartItemButtonType)
@@ -71,6 +77,8 @@ class CartListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+    override fun getItemId(position: Int): Long = position.toLong()
+
     fun getData(): List<CartItem> = dataSet
 
     fun setData(items: List<CartItem>) {
@@ -88,5 +96,23 @@ class CartListAdapter(
     fun updateItem(position: Int, cartItem: CartItem) {
         dataSet[position] = cartItem
         notifyItemChanged(position)
+    }
+
+    companion object {
+        private val diffCallback = object : DiffUtil.ItemCallback<CartItem>() {
+            override fun areItemsTheSame(
+                oldItem: CartItem,
+                newItem: CartItem
+            ): Boolean {
+                return oldItem.wishItem.id == newItem.wishItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: CartItem,
+                newItem: CartItem
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/screens/CartFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/screens/CartFragment.kt
@@ -47,7 +47,8 @@ class CartFragment : Fragment(), CartListAdapter.OnItemClickListener, ImageLoade
         adapter.setImageLoader(this)
         binding.cartList.run {
             this.adapter = adapter
-            layoutManager = LinearLayoutManager(requireContext())
+            itemAnimator = null
+            setItemViewCacheSize(20)
             binding.cartList.addItemDecoration(
                 DividerItemDecoration(
                     binding.cartList.context,

--- a/app/src/main/res/layout/fragment_cart.xml
+++ b/app/src/main/res/layout/fragment_cart.xml
@@ -54,7 +54,8 @@
             android:id="@+id/cart_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_weight="1" />
+            android:layout_weight="1"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"


### PR DESCRIPTION
## What is this PR? 🔍
장바구니화면에서 아이템 수량 변경 시 하단의 구분선이 깜박이는 버그 및 recyclerView 스크롤 시 전체적으로 아이템 이미지가 깜박이는 버그를 수정
## Key Changes 🔑
1. 구분선 깜박이는 버그 수정
   - 원인 : 수량 변경 시 실행되는 > `CartListAdapter.kt` > `updateItem()` > `notifyItemChanged(position)` 실행 시 뷰에 에니메이션 효과가 적용되어 발생하는 버그
   - 해결 : 에니메이션 제거를 위해 recyclerview > `itemAnimator = null` 추가
2. recyclerView 스크롤 시 전반적으로 이미지 깜박임 버그 수정
   -  `setItemViewCacheSize(20)` : 스크롤 되어 화면에 사라진 view에 대해서는 재사용되는 `recycled view pool`에 들어가지 않고, `cache`에 저장(사이즈는 20). 다시 화면에 view가 등장할 때 `onBindViewHolder` 호출 없이 그대로 보여짐
3. 그 외 `recyclerView` 성능 개선
   - 1, 2번 작업도 `recyclerView` 성능 개선에 포함됨
      - `diffCallback` 사용 : 두 `itemList`간의 차이점을 찾고 업데이트 되어야 할 list를 반환, 변경된 list에 대한 부분 업데이트 실행
      - `CartListAdapter.kt` > `RecyclerView.Adapter` -> `ListAdapter` 상속으로 변경, `diffcallback`을 간편하게 사용하기 위함
      - `setHasStableIds(true)`, `getItemId()` : adapter에 Item들이 고유한 ID값을 가진다고 설정, `viewHolder`에 bind된 데이터가 바꾸려는 데이터와 id값이 일치하면 `onBindViewHolder` 호출 없이 그대로 보여짐
   
## To Reviewers 📢
- 아이템 수량 조절 시 이미지 깜박임은 여전히 존재합니다. 해당 경우는 itemCount에 대해서만 UI 변경하도록 수정 중이나 제대로 동작하지 않아서 별도로 PR올려야할 것 같습니다.
