### PR TITLE
[fix] 폴더 리스트 깜박임 및 무분별한 썸네일 이미지가 로드되는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -1,10 +1,13 @@
 package com.hyeeyoung.wishboard.view.folder.adapters
 
 import android.content.Context
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.ItemFolderHorizontalBinding
@@ -17,10 +20,14 @@ import com.hyeeyoung.wishboard.util.extension.navigateSafe
 class FolderListAdapter(
     private val context: Context,
     private val folderListViewType: FolderListViewType,
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : ListAdapter<FolderItem, RecyclerView.ViewHolder>(diffCallback) {
     private val dataSet = arrayListOf<FolderItem>()
     private lateinit var listener: OnItemClickListener
     private lateinit var imageLoader: ImageLoader
+
+    init {
+        setHasStableIds(true)
+    }
 
     interface OnItemClickListener {
         fun onItemClick(item: FolderItem)
@@ -101,6 +108,8 @@ class FolderListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+    override fun getItemId(position: Int): Long = position.toLong()
+
     fun addData(folderItem: FolderItem) {
         dataSet.add(0, folderItem)
         notifyItemInserted(0)
@@ -125,5 +134,20 @@ class FolderListAdapter(
     companion object {
         private const val ARG_FOLDER_ITEM = "folderItem"
         private const val ARG_FOLDER_POSITION = "folderPosition"
+        private val diffCallback = object : DiffUtil.ItemCallback<FolderItem>() {
+            override fun areItemsTheSame(
+                oldItem: FolderItem,
+                newItem: FolderItem
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: FolderItem,
+                newItem: FolderItem
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -47,16 +47,14 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener, ImageL
         binding.folderList.apply {
             this.adapter = adapter
             layoutManager = GridLayoutManager(requireContext(), 2)
+            itemAnimator = null
+            setItemViewCacheSize(20)
         }
     }
 
     private fun addListeners() {
         binding.newFolder.setOnClickListener {
             findNavController().navigateSafe(R.id.action_folder_to_folder_add_dialog)
-        }
-        binding.swipeRefresh.setOnRefreshListener {
-            viewModel.fetchFolderList()
-            binding.swipeRefresh.isRefreshing = false
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
@@ -1,15 +1,14 @@
 package com.hyeeyoung.wishboard.view.folder.screens
 
 import android.os.Bundle
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import androidx.fragment.app.Fragment
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentFolderListBinding
 import com.hyeeyoung.wishboard.model.folder.FolderItem
@@ -39,8 +38,11 @@ class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener, Im
         val adapter = viewModel.getFolderListAdapter()
         adapter.setOnItemClickListener(this)
         adapter.setImageLoader(this)
-        binding.folderList.adapter = adapter
-        binding.folderList.layoutManager = LinearLayoutManager(requireContext())
+        binding.folderList.run {
+            this.adapter = adapter
+            itemAnimator = null
+            setItemViewCacheSize(20)
+        }
     }
 
     override fun onItemClick(item: FolderItem) {

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -58,23 +58,17 @@
                 app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-            android:id="@+id/swipeRefresh"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/folder_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:padding="10dp"
+            android:scrollbarFadeDuration="0"
+            android:scrollbarSize="5dp"
+            android:scrollbarThumbVertical="@android:color/darker_gray"
+            android:scrollbars="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/title_container">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/folder_list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:padding="10dp"
-                android:scrollbarFadeDuration="0"
-                android:scrollbarSize="5dp"
-                android:scrollbarThumbVertical="@android:color/darker_gray"
-                android:scrollbars="vertical" />
-        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+            app:layout_constraintTop_toBottomOf="@id/title_container"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_folder_list.xml
+++ b/app/src/main/res/layout/fragment_folder_list.xml
@@ -59,7 +59,8 @@
                 android:scrollbarFadeDuration="0"
                 android:scrollbarSize="5dp"
                 android:scrollbarThumbVertical="@android:color/darker_gray"
-                android:scrollbars="vertical" />
+                android:scrollbars="vertical"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </LinearLayout>


### PR DESCRIPTION
## What is this PR? 🔍
폴더 리스트 깜박임 및 무분별한 썸네일 이미지가 로드되는 버그 수정

## Key Changes 🔑
1. recyclerView 성능 개선
   - `diffCallback`  사용
   - 어뎁터 `setHasStableIds(true)` 설정
   -  리사이클러뷰 `itemAnimator = null`, `setItemViewCacheSize(20)` 설정 -> 무분별한 썸네일 이미지 로드 해결
   - 불필요한 새로고침 삭제하여 깜박임이 발생하지 않도록 수정

## To Reviewers 📢
- `fragment_folder.xml`은 SwipeRefreshLayout만 제거했습니다! 가볍게 봐주세요!
