### PR TITLE
[fix] 홈에서 스크롤 시 RecyclerView가 깜박이는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -3,18 +3,27 @@ package com.hyeeyoung.wishboard.view.wish.list.adapters
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.databinding.ItemWishBinding
 import com.hyeeyoung.wishboard.model.cart.CartStateType
+import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.util.ImageLoader
+import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
 
 class WishListAdapter(
     private val context: Context
-) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+) : ListAdapter<WishItem, RecyclerView.ViewHolder>(diffCallback) {
     private val dataSet = arrayListOf<WishItem>()
     private lateinit var listener: OnItemClickListener
     private lateinit var imageLoader: ImageLoader
+
+    init {
+        setHasStableIds(true)
+    }
 
     interface OnItemClickListener {
         fun onItemClick(position: Int, item: WishItem)
@@ -35,7 +44,7 @@ class WishListAdapter(
             val item = dataSet[position]
             with(binding) {
                 this.item = item
-                item.image?.let { imageLoader.loadImage(it, binding.itemImage) }
+                item.image?.let { imageLoader.loadImage(it, itemImage) }
                 binding.cart.isSelected = item.cartState == CartStateType.IN_CART.numValue
 
                 container.setOnClickListener {
@@ -67,6 +76,8 @@ class WishListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
+    override fun getItemId(position: Int): Long = position.toLong()
+
     /** 아이템 정보(타이틀 및 가격 등)수정, cart 포함 여부 수정에 사용 */
     fun updateData(position: Int, wishItem: WishItem) {
         dataSet[position] = wishItem
@@ -82,5 +93,24 @@ class WishListAdapter(
         dataSet.clear()
         dataSet.addAll(items)
         notifyDataSetChanged()
+    }
+
+    companion object {
+        private const val TAG = "wishListAdapter"
+        private val diffCallback = object : DiffUtil.ItemCallback<WishItem>() {
+            override fun areItemsTheSame(
+                oldItem: WishItem,
+                newItem: WishItem
+            ): Boolean {
+                return oldItem.id == newItem.id
+            }
+
+            override fun areContentsTheSame(
+                oldItem: WishItem,
+                newItem: WishItem
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
@@ -26,15 +26,17 @@ import dagger.hilt.android.AndroidEntryPoint
 class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener, ImageLoader {
     private lateinit var binding: FragmentHomeBinding
     private val viewModel: WishListViewModel by activityViewModels()
-    private lateinit var adapter: WishListAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.fetchWishList()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
         binding = FragmentHomeBinding.inflate(inflater, container, false)
-
-        viewModel.fetchWishList()
 
         initializeView()
         addListeners()
@@ -44,11 +46,15 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener, ImageLoade
     }
 
     private fun initializeView() {
-        adapter = viewModel.getWishListAdapter()
+        val adapter = viewModel.getWishListAdapter()
         adapter.setOnItemClickListener(this)
         adapter.setImageLoader(this)
-        binding.wishList.adapter = adapter
-        binding.wishList.layoutManager = GridLayoutManager(requireContext(), 2)
+        binding.wishList.run {
+            this.adapter = adapter
+            layoutManager = GridLayoutManager(requireContext(), 2)
+            itemAnimator = null
+            setItemViewCacheSize(20)
+        }
     }
 
     private fun addListeners() {


### PR DESCRIPTION
## What is this PR? 🔍
홈에서 스크롤 시 RecyclerView가 깜박이는 버그 수정
## Key Changes 🔑
1. recyclerView  > `setItemViewCacheSize(20)`
   - 스크롤 되어 화면에 사라진 view는 재사용되는 `recycled view pool`에 들어가지 않고, `cache`에 저장 다시 화면에 view가 등장할 때 `onBindViewHolder` 호출 없이 그대로 보여짐에 따라 깜박임 완화
2. recyclerView 성능 개선
   - 1번도 recyclerView 성능 개선에 포함됨
   - `WishListAdapter.kt` : `diffCallback` 사용, `setHasStableIds(true)` 설정
