### PR TITLE
[feat] FCM 토큰 등록 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.kt
@@ -1,27 +1,26 @@
 package com.hyeeyoung.wishboard
 
 import android.os.Bundle
-import android.util.Log
 import android.view.View
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
-import com.google.android.gms.tasks.OnCompleteListener
-import com.google.firebase.messaging.FirebaseMessaging
 import com.hyeeyoung.wishboard.databinding.ActivityMainBinding
-import com.hyeeyoung.wishboard.util.prefs
+import com.hyeeyoung.wishboard.viewmodel.MainViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
+    private val viewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_main)
 
-        initFCMToken()
+        viewModel.initFCMToken()
         initializeView()
     }
 
@@ -41,20 +40,6 @@ class MainActivity : AppCompatActivity() {
                     else -> binding.bottomNav.visibility = View.VISIBLE
                 }
             }
-        }
-    }
-
-    private fun initFCMToken() {
-        if (prefs?.getFCMToken() == null) {
-            FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
-                if (!task.isSuccessful) {
-                    Log.w(TAG, "Fetching FCM registration token failed", task.exception)
-                    return@OnCompleteListener
-                }
-                val token = task.result
-                Log.d(TAG, token)
-                prefs?.setFCMToken(token)
-            })
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/di/RepositoryModule.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/di/RepositoryModule.kt
@@ -10,6 +10,8 @@ import com.hyeeyoung.wishboard.repository.wish.WishRepository
 import com.hyeeyoung.wishboard.repository.wish.WishRepositoryImpl
 import com.hyeeyoung.wishboard.repository.sign.SignRepository
 import com.hyeeyoung.wishboard.repository.sign.SignRepositoryImpl
+import com.hyeeyoung.wishboard.repository.user.UserRepository
+import com.hyeeyoung.wishboard.repository.user.UserRepositoryImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -47,5 +49,11 @@ object RepositoryModule {
     @Provides
     fun provideGalleryRepository(): GalleryRepository {
         return GalleryRepositoryImpl()
+    }
+
+    @Singleton
+    @Provides
+    fun provideUserRepository(): UserRepository {
+        return UserRepositoryImpl()
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -110,6 +110,14 @@ interface RemoteService {
         @Path("folder_id") folderId: Long,
     ): Response<RequestResult>
 
+    // 사용자
+    @FormUrlEncoded
+    @PUT("user/fcm")
+    suspend fun updateFCMToken(
+        @Header("Authorization") userToken: String,
+        @Field("fcm_token") fcmToken: String
+    ): Response<RequestResult>
+
     companion object {
         val api = Retrofit.Builder()
             .baseUrl(BuildConfig.BASE_URL)

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/user/UserRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/user/UserRepository.kt
@@ -1,0 +1,5 @@
+package com.hyeeyoung.wishboard.repository.user
+
+interface UserRepository {
+    suspend fun registerFCMToken(userToken: String, fcmToken: String): Boolean
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/user/UserRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/user/UserRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.hyeeyoung.wishboard.repository.user
+
+import android.util.Log
+import com.hyeeyoung.wishboard.remote.RemoteService
+
+class UserRepositoryImpl : UserRepository {
+    private val api = RemoteService.api
+
+    override suspend fun registerFCMToken(userToken: String, fcmToken: String): Boolean {
+        val response = api.updateFCMToken(userToken, fcmToken)
+        if (response.isSuccessful) {
+            Log.d(TAG, "FCM 토큰 등록 성공")
+        } else {
+            Log.e(TAG, "FCM 토큰 등록 실패: ${response.code()}")
+        }
+        return response.isSuccessful
+    }
+
+    companion object {
+        private const val TAG = "UserRepositoryImpl"
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/MainViewModel.kt
@@ -1,0 +1,43 @@
+package com.hyeeyoung.wishboard.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.android.gms.tasks.OnCompleteListener
+import com.google.firebase.messaging.FirebaseMessaging
+import com.hyeeyoung.wishboard.repository.user.UserRepository
+import com.hyeeyoung.wishboard.util.prefs
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+) : ViewModel() {
+
+    fun initFCMToken() {
+        val userToken = prefs?.getUserToken() ?: return
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(OnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Log.w(TAG, "Fetching FCM registration token failed", task.exception)
+                return@OnCompleteListener
+            }
+
+            val fcmToken = task.result
+            Log.d(TAG, fcmToken)
+
+            if (prefs?.getFCMToken() != fcmToken) {
+                prefs?.setFCMToken(fcmToken)
+                viewModelScope.launch(Dispatchers.IO) {
+                    userRepository.registerFCMToken(userToken, fcmToken)
+                }
+            }
+        })
+    }
+
+    companion object {
+        private const val TAG = "MainViewModel"
+    }
+}


### PR DESCRIPTION
## What is this PR? 🔍
FCM 토큰 값 생성 및 변경 시 서버에 FCM 토큰 업데이트를 요청

## Key Changes 🔑
1. user 정보(token)가 존재하며, fcm 토큰 생성됐거나 변경된 경우, registerFCMToken() 요청
   - `FirebaseMessaging.getInstance().token` : 현재 토큰 가져오는 리스너를 `MainActivity.kt` -> `MainViewModel.kt`로 이동
   - 저장된 FCM과 현재 토큰을 비교한 후 변경됐을 때 `registerFCMToken()` 요청

## To Reviewers 📢
- 토큰 생성 및 변경 시 요청하기 때문에 regist
- FCM 토큰을 앱 내부에 저장하지 않고, `FireBaseMessagingService.kt` > `onNewToken()`에서 바로 FCM 등록 요청을 보내고 싶었으나 다음과 같은 이유로 앱 내 FCM 토큰 저장이 불가피함
   1. 태스트 했을 때 앱 삭제하지 않는 이상, 해당 함수 실행 안됨 (동일 기기로 로그아웃 후 다른 아이디로 다른 아이디로 가입했을 때 실행 안됨)
   2. 함수가 실행된다해도 해당 함수는 인트로 화면 진입 시 바로 실행되기 때문에(가입 프로세스 진행 전 바로 실행) 가입 완료까지 어딘가에 해당 값을 저장해두고, 가입 완료 후 DB에 `user_id`가 존재하는 상태에서 토큰 값을 저장해야함
```kotlin
    /** 새 토큰 생성 및 토큰 갱신 */
    override fun onNewToken(token: String) {
        super.onNewToken(token)
        Log.d(TAG, "Refreshed token: $token")
    }
```
