### PR TITLE
[fix] 아이템 폴더 지정 시 폴더탭에 반영되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -26,6 +26,11 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener, ImageL
     private lateinit var binding: FragmentFolderBinding
     private val viewModel: FolderViewModel by activityViewModels()
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.fetchFolderList()
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -30,10 +30,6 @@ class FolderViewModel @Inject constructor(
     private var isExistFolderName = MutableLiveData<Boolean>()
     private var isEditMode = MutableLiveData<Boolean>()
 
-    init {
-        fetchFolderList()
-    }
-
     fun fetchFolderList() {
         if (token == null) return
         viewModelScope.launch {


### PR DESCRIPTION
## What is this PR? 🔍
폴더가 지정되어있지 않은 아이템에 폴더를 지정한 후 폴더탭으로 들어가면 썸네일이나 아이템 개수가 업데이트 되어있지 않은 버그를 수정

## Key Changes 🔑
1. 폴더탭 들어올 때마다(back해서 복귀하는 경우 제외), fetch 요청