### PR TITLE
[mod] 폴더 리스트 ui 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -3,6 +3,7 @@ package com.hyeeyoung.wishboard.view.folder.adapters
 import android.content.Context
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.core.os.bundleOf
 import androidx.navigation.findNavController
@@ -24,6 +25,7 @@ class FolderListAdapter(
     private val dataSet = arrayListOf<FolderItem>()
     private lateinit var listener: OnItemClickListener
     private lateinit var imageLoader: ImageLoader
+    private var selectedFolderPosition: Int? = null
 
     init {
         setHasStableIds(true)
@@ -67,11 +69,17 @@ class FolderListAdapter(
         RecyclerView.ViewHolder(binding.root) {
         fun bind(position: Int) {
             val item = dataSet[position]
-
             with(binding) {
                 this.item = item
+                check.visibility = if (selectedFolderPosition == position) {
+                    View.VISIBLE
+                } else {
+                    View.INVISIBLE
+                }
+                thumbnail.clipToOutline = true
                 item.thumbnail?.let { imageLoader.loadImage(it, thumbnail) }
                 container.setOnClickListener {
+                    selectedFolderPosition = position
                     listener.onItemClick(item)
                 }
             }

--- a/app/src/main/res/drawable/ic_check.xml
+++ b/app/src/main/res/drawable/ic_check.xml
@@ -1,16 +1,13 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="23dp"
-    android:height="23dp"
-    android:viewportWidth="23"
-    android:viewportHeight="23">
+    android:width="14dp"
+    android:height="12dp"
+    android:viewportWidth="14"
+    android:viewportHeight="12">
   <path
-      android:pathData="M11.5,11.5m-11.5,0a11.5,11.5 0,1 1,23 0a11.5,11.5 0,1 1,-23 0"
-      android:fillColor="#7cf885"/>
-  <group>
-    <clip-path
-        android:pathData="M7,7h9.907v9.061h-9.907z"/>
-    <path
-        android:pathData="M10.908,16.061a0.453,0.453 0,0 1,-0.32 -0.133L7.132,12.473a0.452,0.452 0,1 1,0.637 -0.64L10.89,14.947 16.112,9.075a0.454,0.454 0,0 1,0.68 0.6L11.246,15.91a0.553,0.553 0,0 1,-0.338 0.151"
-        android:fillColor="#292929"/>
-  </group>
+      android:pathData="M13.2355,1.769C13.522,1.3628 13.4249,0.8013 13.0187,0.5148C12.6125,0.2283 12.051,0.3254 11.7645,0.7316L5.7298,9.2883L2.1824,5.1634C1.8583,4.7866 1.2901,4.7438 0.9132,5.0679C0.5363,5.392 0.4936,5.9602 0.8177,6.3371L5.1177,11.3371C5.2985,11.5474 5.5662,11.6625 5.8432,11.6492C6.1203,11.6359 6.3757,11.4956 6.5355,11.269L13.2355,1.769Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.2"
+      android:fillColor="#73F87C"
+      android:strokeColor="#73F87C"
+      android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/layout/fragment_folder_list.xml
+++ b/app/src/main/res/layout/fragment_folder_list.xml
@@ -9,35 +9,33 @@
         <import type="androidx.navigation.Navigation" />
     </data>
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/white"
-        android:orientation="vertical">
+        android:background="@color/white">
 
-        <!-- TODO padding 조정 -->
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="20dp">
+            app:layout_constraintTop_toTopOf="parent">
 
             <ImageButton
                 android:id="@+id/back"
+                style="@style/Widget.Button.Icon.Navigation"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
                 android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}"
                 android:src="@drawable/ic_back"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
+                style="@style/Widget.Tab.Detail.TextAppearance.Title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:fontFamily="@font/nanum_square_eb"
                 android:text="@string/folder_list_title"
-                android:textColor="@color/gray_700"
-                android:textSize="15dp"
+                app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -46,22 +44,23 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="0.5dp"
-            android:background="@color/gray_700" />
+            android:background="@color/gray_100"
+            app:layout_constraintTop_toTopOf="@id/folder_list" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/folder_list"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="0dp"
+            android:scrollbarFadeDuration="0"
+            android:scrollbarSize="5dp"
+            android:scrollbarThumbVertical="@android:color/darker_gray"
+            android:scrollbars="vertical"
+            app:dividerColor="@{@color/gray_100}"
+            app:dividerHeight="@{2f}"
+            app:dividerPadding="@{0f}"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar" />
 
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/folder_list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scrollbarFadeDuration="0"
-                android:scrollbarSize="5dp"
-                android:scrollbarThumbVertical="@android:color/darker_gray"
-                android:scrollbars="vertical"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_folder_horizontal.xml
+++ b/app/src/main/res/layout/item_folder_horizontal.xml
@@ -14,57 +14,42 @@
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingHorizontal="20dp"
-        android:paddingVertical="10dp">
+        android:paddingHorizontal="@dimen/spacingBase"
+        android:paddingVertical="@dimen/spacingSmall">
 
-        <de.hdodenhof.circleimageview.CircleImageView
+        <ImageView
             android:id="@+id/thumbnail"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:foreground="@color/ultraSemiTransparent"
+            android:background="@drawable/shape_border_radius_32"
+            android:foreground="@color/semiTransparent"
             android:scaleType="centerCrop"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:src="@drawable/sample" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout"
+        <TextView
+            android:id="@+id/folder_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="5dp"
-            android:gravity="center_vertical"
+            android:layout_marginStart="@dimen/spacing10"
+            android:fontFamily="@font/suit_r"
+            android:text="@{item.name}"
+            android:textColor="@color/gray_700"
+            android:textSize="@dimen/typographyBase"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/check"
+            app:layout_constraintStart_toEndOf="@id/thumbnail"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="폴더명" />
+
+        <ImageView
+            android:id="@+id/check"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_check"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/thumbnail"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <TextView
-                android:id="@+id/folder_name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="20dp"
-                android:layout_weight="1"
-                android:fontFamily="@font/nanum_square_b"
-                android:text="@{item.name}"
-                android:textColor="@color/gray_700"
-                android:textSize="15sp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toStartOf="@id/btn_radio"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="폴더명" />
-
-            <RadioButton
-                android:id="@+id/btn_radio"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                android:button="@drawable/selector_checkbox"
-                android:state_checked="false"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            app:layout_constraintTop_toTopOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## What is this PR? 🔍
아이템 기본 업로드 > 폴더 리스트 ui 수정

## Key Changes 🔑
1. 선택된 폴더는 체크 아이콘으로 표시
   - 폴더 선택 -> 업로드 화면 복귀 -> 폴더 리스트 화면 재진입 시 이전에 선택된 폴더 뷰에서 체크 아이콘의 `visibility`를 `visible`로 조정
2. 폴더 클릭 시 클릭 효과 보여주기(피드백 반영)
   - 폴더 뷰에 잠깐 동안 회색 배경이 보임

## To Reviewers 📢
- 유의 사항
1. 폴더 선택 시 바로 메인으로 이동되기 때문에 폴더 뷰에서 체크아이콘을 확인 하지 못합니다!
   - 다시 폴더 리스트 화면으로 재진입 시 이전에 선택된 폴더 뷰의 체크아이콘을 확인 할 수 있습니다.
2. 한가지 거슬리는 점 : 1번 사진과 같이 이전에 선택된 폴더의 체크 표시는 그대로 남아 있는 채, 클릭한 폴더 뷰의 배경이 잠시 회색으로 보임 
   - 2번 사진 처럼 폴더 리스트 재진입 시 마지막에 선택된 폴더에 체크 표시되어있긴 함
   - 해당 문제는 테스트해보면서 아래 보기 중에 하나 택해서 코드 수정할 예정 (피드백 부탁합니다!) 
      - 버튼 누름 효과를 제거(회색 배경제거)
      - 체크 표시 제거
      - 괜찮다면 이대로 유지
![Screenshot_20220223-212810_Wishboard](https://user-images.githubusercontent.com/48701368/155319625-ea67311e-c837-418f-b9a2-5b45d448e7bb.jpg) 
![Screenshot_20220223-212834_Wishboard](https://user-images.githubusercontent.com/48701368/155319630-6a326b43-c2f8-4130-b1ec-19ad1210eaa7.jpg)

