### PR TITLE
[fix] 아이템 수정 시 알림 정보가 존재할 경우, 알림정보가 null로 보이는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/util/DateFormatUtil.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/DateFormatUtil.kt
@@ -61,7 +61,7 @@ fun shortDateYMD(date: Date): String? {
 
 /** 날짜를 "yy. M. d a h:mm" 포맷으로 변경 */
 fun shortDateYMDAHM(date: String?): String? {
-    val inputDateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    val inputDateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm")
     val outputDateFormat = SimpleDateFormat("yy. M. d a h:mm")
     val inputDate: Date?
     val outputDate: String


### PR DESCRIPTION
## What is this PR? 🔍
아이템 수정 시 알림 정보가 존재할 경우, 알림정보가 null로 보이는 버그 수정

## Key Changes 🔑
1. 서버에서 받아온 notiDate를 Date 타입으로 변환 시 포맷을 초단위 -> 분단위 포맷으로 적용
   - 서버에서 전달 받은 notiDate를 초단위까지 적용하여 타입 변환했던 것이 원인
   - 서버에서 notiDate 분단위까지 보내주므로 타입 불일치에 따라 null을 반환한 것이었음