### PR TITLE
[feat] 회원가입 시 가입 계정 체크 API 요청 및 가입 여부에 따라 detail 메세지 보여주기 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/RemoteService.kt
@@ -38,6 +38,13 @@ interface RemoteService {
         @Field("email") email: String
     ): Response<RequestResultData>
 
+
+    @FormUrlEncoded
+    @POST("auth/check-email")
+    suspend fun checkRegisteredUser(
+        @Field("email") email: String
+    ): Response<RequestResult>
+
     // 위시리스트 및 아이템
     @GET("item")
     suspend fun fetchWishList(@Header("Authorization") token: String): Response<List<WishItem>>?

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepository.kt
@@ -5,4 +5,5 @@ interface SignRepository {
     suspend fun signIn(email: String, password: String): Boolean
     suspend fun signInEmail(email: String): Boolean
     suspend fun requestVerificationMail(email: String): Pair<Pair<Boolean, String?>, Int>
+    suspend fun checkRegisteredUser(email: String): Pair<Boolean, Int>
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
@@ -63,6 +63,16 @@ class SignRepositoryImpl : SignRepository {
         return Pair(Pair(response.isSuccessful, result?.data?.verificationCode), response.code())
     }
 
+    override suspend fun checkRegisteredUser(email: String): Pair<Boolean, Int> {
+        val response = api.checkRegisteredUser(email)
+        if (response.isSuccessful) {
+            Log.d(TAG, "가입 가능 검사 성공")
+        } else {
+            Log.e(TAG, "가입 가능 검사 실패: ${response.code()}")
+        }
+        return Pair(response.isSuccessful, response.code())
+    }
+
     companion object {
         private const val TAG = "SignRepositoryImpl"
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/sign/screens/SignUpEmailFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/sign/screens/SignUpEmailFragment.kt
@@ -31,14 +31,16 @@ class SignUpEmailFragment : Fragment() {
         binding.viewModel = viewModel
         binding.lifecycleOwner = this@SignUpEmailFragment
 
-        addListeners()
+        addObservers()
 
         return binding.root
     }
 
-    private fun addListeners() {
-        binding.next.setOnClickListener {
-            findNavController().navigateSafe(R.id.action_email_to_password)
+    private fun addObservers() {
+        viewModel.isUnregisteredUser().observe(viewLifecycleOwner) { isUnregistered ->
+            if (isUnregistered == true) {
+                findNavController().navigateSafe(R.id.action_email_to_password)
+            }
         }
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/SignViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/SignViewModel.kt
@@ -76,7 +76,31 @@ class SignViewModel @Inject constructor(
         }
     }
 
+    fun checkRegisteredUser() {
+        viewModelScope.launch {
+            registrationEmail.value?.let { email ->
+                val result = signRepository.checkRegisteredUser(email)
+                setRegisteredUser(result.first, result.second)
+            }
+        }
+    }
+
+    private fun setRegisteredUser(isSuccessful: Boolean, resultCode: Int) {
+        isUnregisteredUser.value = when {
+            isSuccessful -> {
+                true
+            }
+            resultCode == 409 -> {
+                false
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
     fun onRegistrationEmailTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {
+        isUnregisteredUser.value = null
         registrationEmail.value = s.toString().trim()
         checkEmailFormatValidation(registrationEmail.value)
     }
@@ -133,10 +157,12 @@ class SignViewModel @Inject constructor(
     }
 
     fun resetRegistrationEmail() {
+        isUnregisteredUser.value = null
         registrationEmail.value = null
     }
 
     fun resetRegistrationPassword() {
+        isUnregisteredUser.value = null
         registrationPassword.value = null
     }
 

--- a/app/src/main/res/layout/fragment_sign_up_email.xml
+++ b/app/src/main/res/layout/fragment_sign_up_email.xml
@@ -12,6 +12,8 @@
 
         <import type="com.hyeeyoung.wishboard.R" />
 
+        <import type="android.view.View" />
+
         <import type="androidx.navigation.Navigation" />
     </data>
 
@@ -60,13 +62,6 @@
                 tools:text="1/2 단계" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <androidx.constraintlayout.widget.Guideline
-            android:id="@+id/guide_center"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintGuide_percent="0.5" />
-
         <ImageView
             android:id="@+id/email_icon"
             android:layout_width="wrap_content"
@@ -92,29 +87,45 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/email_icon" />
 
-        <EditText
-            android:id="@+id/email_input"
-            style="@style/Widget.EditText.Basic"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/spacingBase"
-            android:hint="@string/email_input_text"
-            android:inputType="textEmailAddress"
-            android:onTextChanged="@{viewModel::onRegistrationEmailTextChanged}"
-            android:text="@{viewModel.registrationEmail}"
-            android:textAppearance="@style/Widget.EditText.Basic.TextAppearance"
-            app:layout_constraintBottom_toTopOf="@id/next" />
+            android:layout_marginTop="32dp"
+            android:orientation="vertical"
+            app:layout_constraintTop_toBottomOf="@id/password_detail">
 
-        <Button
-            android:id="@+id/next"
-            style="@style/Widget.Button.Activate.Green"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:enabled="@{viewModel.validEmailFormat == true}"
-            android:text="@string/next"
-            android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
-            app:layout_constraintBottom_toTopOf="@id/guide_center"
-            app:layout_constraintEnd_toEndOf="parent" />
+            <EditText
+                android:id="@+id/email_input"
+                style="@style/Widget.EditText.Basic"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/email_input_text"
+                android:inputType="textEmailAddress"
+                android:onTextChanged="@{viewModel::onRegistrationEmailTextChanged}"
+                android:text="@{viewModel.registrationEmail}"
+                android:textAppearance="@style/Widget.EditText.Basic.TextAppearance" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/spacingBase"
+                android:layout_marginTop="@dimen/spacing5"
+                android:text="@{viewModel.validEmailFormat == false ? context.getString(R.string.sign_email_format_detail_text) : (viewModel.isUnregisteredUser() != null &amp;&amp; viewModel.isUnregisteredUser() == false) ? context.getString(R.string.sign_up_email_registered_user_detail_text) : ``}"
+                android:textAppearance="@style/Widget.TextAppearance.Detail"
+                android:visibility="@{viewModel.registrationEmail.length() > 0 &amp;&amp; (viewModel.validEmailFormat == false || (viewModel.isUnregisteredUser() != null &amp;&amp; viewModel.isUnregisteredUser() == false)) ? View.VISIBLE : View.GONE}"
+                tools:text="@string/sign_up_email_registered_user_detail_text" />
+
+            <Button
+                android:id="@+id/next"
+                style="@style/Widget.Button.Activate.Green"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/spacingBase"
+                android:onClick="@{() -> viewModel.checkRegisteredUser()}"
+                android:enabled="@{viewModel.validEmailFormat == true}"
+                android:text="@string/next"
+                android:textAppearance="@style/Widget.Button.Basic.TextAppearance" />
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="verification_code_input_text">인증 코드</string>
     <string name="sign_email_format_detail_text">메일 주소를 정확하게 입력해 주세요.</string>
     <string name="sign_email_unregistered_user_detail_text">앗, 가입되지 않은 계정이에요! 가입하기부터 진행해 주세요.</string>
+    <string name="sign_up_email_registered_user_detail_text">앗, 이미 가입된 계정이에요! 로그인으로 진행해 주세요.</string>
     <string name="sign_password_detail_text">8자리 이상의 영문자, 숫자, 특수 문자 조합으로 입력해주세요.</string>
     <string name="sign_verification_code_toast_text">인증코드를 다시 확인해 주세요.</string>
     <string name="sign_up_email_guide_text">이메일 인증으로 비밀번호를 찾을 수 있어요.\n실제 사용될 이메일로 입력해주세요!</string>


### PR DESCRIPTION
## What is this PR? 🔍
회원가입 시 가입 계정 체크 API 요청한 후, 서버에서 전달받은 가입 여부 값(isSuccessful)에 따라 detail 메세지 보여주기 구현
## Key Changes 🔑
1. 회원가입 > 이메일 입력 완료 시 checkEmail api 요청, 요청 결과 값에 따라 미가입자 여부를 판별
   - resultCode == 409 : 가입자
   - isSuccessful : 미가입자

2. 미가입자 여부에 따라 ui 구현
   - 가입자 : "앗, 이미 가입된 계정이에요! 로그인으로 진행해 주세요." 디테일 메세지 띄우기
   - 미가입자 : 패스워드 화면으로 이동

## To Reviewers 📢
- 빠르게 이메일 검증 api를 추가해주신 혜정님께 감사의 말씀 전합니다 💖 멋쟁이..😎
