### PR TITLE
[fix] 아이템 일반 업로드 방식으로 아이템 추가 또는 수정 후 이전 화면으로 복귀 시 ui가 업데이트 되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItemStatus.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItemStatus.kt
@@ -1,0 +1,5 @@
+package com.hyeeyoung.wishboard.model.wish
+
+enum class WishItemStatus {
+    ADDED, MODIFIED, DELETED
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -74,6 +74,11 @@ class WishListAdapter(
 
     override fun getItemId(position: Int): Long = position.toLong()
 
+    fun insertData(wishItem: WishItem) {
+        dataSet.add(0, wishItem)
+        notifyItemInserted(0)
+    }
+
     /** 아이템 정보(타이틀 및 가격 등)수정, cart 포함 여부 수정에 사용 */
     fun updateData(position: Int, wishItem: WishItem) {
         dataSet[position] = wishItem

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/screens/HomeFragment.kt
@@ -12,8 +12,8 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentHomeBinding
 import com.hyeeyoung.wishboard.model.wish.WishItem
+import com.hyeeyoung.wishboard.model.wish.WishItemStatus
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
-import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.wish.list.adapters.WishListAdapter
 import com.hyeeyoung.wishboard.viewmodel.WishListViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -67,11 +67,20 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
         findNavController().currentBackStackEntry?.savedStateHandle?.getLiveData<Bundle>(
             ARG_WISH_ITEM_INFO
         )?.observe(viewLifecycleOwner) {
-            safeLet(
-                it[ARG_WISH_ITEM_POSITION] as? Int,
-                it[ARG_WISH_ITEM] as? WishItem
-            ) { position, withITem ->
-                viewModel.deleteWishItem(position, withITem)
+            (it[ARG_ITEM_STATUS] as? WishItemStatus)?.let { status ->
+                val position = it[ARG_WISH_ITEM_POSITION] as? Int
+                val item = it[ARG_WISH_ITEM] as? WishItem
+                when (status) {
+                    WishItemStatus.MODIFIED -> {
+                        viewModel.updateWishItem(position ?: return@let, item ?: return@let)
+                    }
+                    WishItemStatus.DELETED -> {
+                        viewModel.deleteWishItem(position ?: return@let, item ?: return@let)
+                    }
+                    WishItemStatus.ADDED -> {
+                        viewModel.fetchLatestItem()
+                    }
+                }
             }
         }
     }
@@ -95,5 +104,6 @@ class HomeFragment : Fragment(), WishListAdapter.OnItemClickListener {
         private const val ARG_WISH_ITEM = "wishItem"
         private const val ARG_WISH_ITEM_POSITION = "position"
         private const val ARG_WISH_ITEM_INFO = "wishItemInfo"
+        private const val ARG_ITEM_STATUS = "itemStatus"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
@@ -150,9 +150,9 @@ class WishItemRegistrationViewModel @Inject constructor(
                 val isSuccessful = AWSS3Service().uploadFile(imageFile!!.name, imageFile!!)
                 if (!isSuccessful) return@withContext
 
-                val item = WishItem(
+                wishItem = WishItem(
                     name = name,
-                    image = imageFile?.name,
+                    image = imageFile!!.name,
                     price = itemPrice.value?.replace(",", "")?.toIntOrNull(),
                     url = itemUrl.value,
                     memo = itemMemo.value?.trim(),
@@ -161,7 +161,8 @@ class WishItemRegistrationViewModel @Inject constructor(
                     notiType = notiType.value,
                     notiDate = notiDate.value
                 )
-                val isComplete = wishRepository.uploadWishItem(token, item)
+
+                val isComplete = wishRepository.uploadWishItem(token, wishItem!!)
                 isCompleteUpload.postValue(isComplete)
                 itemRegistrationStatus.postValue(ProcessStatus.IDLE)
             }
@@ -183,7 +184,7 @@ class WishItemRegistrationViewModel @Inject constructor(
                 id = itemId,
                 createAt = wishItem?.createAt,
                 name = itemName,
-                image = imageFile?.name,
+                image = imageFile?.name ?: wishItem?.image,
                 price = itemPrice.value?.replace(",", "")?.toIntOrNull(),
                 url = itemUrl.value,
                 memo = itemMemo.value?.trim(),

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.repository.wish.WishRepository
+import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.util.prefs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -29,8 +30,15 @@ class WishItemViewModel @Inject constructor(
         }
     }
 
-    fun setWishItem(wishItem: WishItem) {
-        this.wishItem.value = wishItem
+    fun setWishItem(item: WishItem) { // TODO refactoring
+        if (item.imageUrl == null && item.image != null) {
+            viewModelScope.launch {
+                item.imageUrl = AWSS3Service().getImageUrl(item.image)
+                wishItem.value = item // 이미지 다운로드까지 시간이 소요됨에 따라 if 문 밖에서 해당 코드 실행할 경우, imageUrl이 초기화 되기 전에 wishItem을 초기화함
+            }
+        } else {
+            wishItem.value = item
+        }
     }
 
     fun getWishItem(): LiveData<WishItem> = wishItem

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishListViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishListViewModel.kt
@@ -46,6 +46,22 @@ class WishListViewModel @Inject constructor(
         }
     }
 
+    fun fetchLatestItem() { // TODO 가장 최근에 등록된 아이템 가져오기
+        if (token == null) return
+        viewModelScope.launch {
+            var items: List<WishItem>?
+            withContext(Dispatchers.IO) {
+                items = wishRepository.fetchWishList(token)
+                items?.forEach { item ->
+                    item.image?.let { item.imageUrl = AWSS3Service().getImageUrl(it) }
+                }
+            }
+            withContext(Dispatchers.Main) {
+                wishListAdapter.insertData(items?.get(0) ?: return@withContext)
+            }
+        }
+    }
+
     fun fetchFolderItems(folderId: Long?) { // TODO need refactoring
         if (token == null || folderId == null) return
         viewModelScope.launch {
@@ -87,6 +103,14 @@ class WishListViewModel @Inject constructor(
         } else {
             CartStateType.IN_CART.numValue
         }
+    }
+
+    fun insertWishItem(wishItem: WishItem) {
+        wishListAdapter.insertData(wishItem)
+    }
+
+    fun updateWishItem(position: Int, wishItem: WishItem) {
+        wishListAdapter.updateData(position, wishItem)
     }
 
     fun deleteWishItem(position: Int, wishItem: WishItem) {

--- a/app/src/main/res/layout/fragment_wish_item_detail.xml
+++ b/app/src/main/res/layout/fragment_wish_item_detail.xml
@@ -33,7 +33,6 @@
             <ImageButton
                 android:id="@+id/back"
                 style="@style/Widget.Button.Icon.Navigation"
-                android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}"
                 android:src="@drawable/ic_back"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />


### PR DESCRIPTION
## What is this PR? 🔍
아이템 추가 및 수정 시 홈화면 ui가 업데이트 되지 않는 버그 수정
## Key Changes 🔑
1. `WishItemStatus` enum class 추가
   - 아이템 추가, 수정, 삭제 시 ui 업데이트를 다른 방식으로 처리하기 위해 구분이 필요하여 추가함
```kotlin
// 홈화면 ui 업데이트
when (status) {
                    WishItemStatus.MODIFIED -> {
                        viewModel.updateWishItem(position ?: return@let, item ?: return@let)
                    }
                    WishItemStatus.DELETED -> {
                        viewModel.deleteWishItem(position ?: return@let, item ?: return@let)
                    }
                    WishItemStatus.ADDED -> {
                        viewModel.fetchLatestItem()
                    }
                }
```
2. 아이템 수정 후 홈화면 ui 업데이트 되지 않는 버그 해결
   - 원인 : 상세조회에서 홈으로 복귀 시 변경된 아이템 정보를 전달하는 코드의 부재
        - 아이템 수정 후 fetch 했었던 방식 -> 아이템 첫 로드시에만 fetch 하는 방식으로 변경됨에 따라 해당 처리가 필요하게됨
   - 해결 : 아이템 수정 detail 화면으로 복귀 -> detail에서 back버튼 눌러 홈으로 복귀 시 변경된 아이템 정보를 전달하여 해당 item ui를 업데이트
3. 아이템 추가 후 홈화면 ui 업데이트 되지 않는 버그 해결
   - 원인 : 해당 처리를 하는 코드의 부재
   - 해결 : 아이템 추가 후 홈으로 복귀 시 `WishItemStatus.ADDED`를 전달하고, 해당 경우에 가장 최근에 등록된 아이템을 가져와서 ui를 업데이트
      - _아이템 수정과 동일한 로직으로 처리하지 못한 이유 : 추가된 아이템 정보를 홈으로 전달할 경우, 추가된 아이템의 id정보와 create_at정보를 갖고 있지 않기 때문에 서버에서 아이템을 fetch 하는 방식으로 아이템의 완전한 정보를 가져오도록 하기 위함_
      - 가장 최근 아이템 fetch 하는 코드는 현재 api가 존재하지 않기 때문에 기존 selectItem api를 호출하여 index 0번 아이템으로 ui 업데이트 하고 있음

## To Reviewers 📢
- 배포 이후 아이템 수정과 동일하게 아이템 일반등록으로 추가 시 추가된 아이템의 상세조회 화면으로 넘어가도록 수정하면 좋을 것 같습니다! (배포 이후에 논의해봅시다!!)
- 가장 최근 아이템을 fetch 해오는 코드가 있으면 좋을 것 같습니다! 현재 안드에서 임시 방편으로 최근 아이템 가져오는 코드(비효율적임)가 있어서 급하지 않지만 여유가 되신다면 추가 요청 부탁드릴게요! 아니면 아이템 추가 후 ui업데이트 방식 관련해서 다른 좋은 아이디어가 있다면 제안해주셔도 좋습니다!
- 아이템 디테일 -> 아이템 수정으로 진입하는 루트가 상당히 많습니다. 남은 경우도 ui가 업데이트 되도록 작업하겠습니다!
   - 장바구니 -> 아이템 디테일
   - 폴더 디테일 -> 아이템 디테일
   - 홈 -> 아이템 디테일 (완료)