### PR TITLE
[feat] push_state에 따라 마이페이지 알림 스위치 on/off ui를 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/util/PreferenceUtil.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/PreferenceUtil.kt
@@ -9,7 +9,6 @@ class PreferenceUtil(context: Context) { // TODO need refactoring
         private const val PREF_USER_TOKEN = "token"
         private const val PREF_USER_NICKNAME = "nickname"
         private const val PREF_FCM_TOKEN = "fcmToken"
-        private const val PREF_PUSH_NOTI = "pushNoti"
     }
 
     private val prefs: SharedPreferences =
@@ -46,13 +45,5 @@ class PreferenceUtil(context: Context) { // TODO need refactoring
 
     fun getFCMToken(): String? {
         return prefs.getString(PREF_FCM_TOKEN, null)
-    }
-
-    fun getCheckedPushNoti(): Boolean {
-        return prefs.getBoolean(PREF_PUSH_NOTI, false)
-    }
-
-    fun setCheckedPushNoti(isChecked: Boolean) {
-        prefs.edit().putBoolean(PREF_PUSH_NOTI, isChecked).apply()
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyFragment.kt
@@ -15,7 +15,6 @@ import com.hyeeyoung.wishboard.databinding.FragmentMyBinding
 import com.hyeeyoung.wishboard.model.common.DialogButtonReplyType
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.loadProfileImage
-import com.hyeeyoung.wishboard.util.prefs
 import com.hyeeyoung.wishboard.view.common.screens.DialogListener
 import com.hyeeyoung.wishboard.view.common.screens.TwoButtonDialogFragment
 import com.hyeeyoung.wishboard.view.sign.screens.SignActivity
@@ -52,11 +51,8 @@ class MyFragment : Fragment() {
     }
 
     private fun addListeners() {
-        prefs?.getCheckedPushNoti()?.let {
-            binding.notiSwitch.isChecked = it
-        }
-        binding.notiSwitch.setOnCheckedChangeListener { _, isChecked ->
-            viewModel.updatePushNotiSettings(isChecked)
+        binding.notiSwitch.setOnClickListener {
+            viewModel.updatePushNotiSettings()
         }
         binding.logout.setOnClickListener {
             showLogoutDialog()

--- a/app/src/main/res/layout/fragment_my.xml
+++ b/app/src/main/res/layout/fragment_my.xml
@@ -157,7 +157,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_marginEnd="@dimen/spacing5"
-                            android:checked="true"
+                            android:checked="@{viewModel.pushState}"
                             app:switchMinWidth="50dp"
                             app:thumbTint="@color/white"
                             app:trackTint="@color/selector_switch_track" />


### PR DESCRIPTION
## What is this PR? 🔍
`selectUserInfo()` api 요청 시 전달받는 `push_state` 값에 따라 알림 스위치(on/off) ui를 업데이트를 구현

## Key Changes 🔑
1. 전달받는 `push_state`값에 따라 알림 스위치(on/off) ui가 업데이트 되도록 구현
   - ui 업데이트를 위해 `LiveData` 타입의 `pushState` 변수를 추가
   - 해당 변수는 유저의 `push_state`값을 불러올 때와 알림 스위치 변경 시 값이 변경됨
   - `pushState`값을 `databinding`해서 ui 업데이트 : android:checked="@{viewModel.pushState}"
<br>

2. 스위치 on/off값 변경 감지 리스너를 `setOnCheckedChangeListener` -> `setOnClickListener`로 교체
      ```
       1. 스위치를 변경한 경우 : pushState 업데이트 api 요청 + 스위치 ui업데이트
       2. 마이페이지 진입 시 push_state값 fetch : only 스위치 ui 업데이트
      ```
   기존 : `setOnCheckedChangeListener`를 사용하면 2번 경우에도 스위치 ui업데이트를 요청할 수 있음**
   변경 : `setOnClickListener`로 교체하면서 데이터 바인딩 상관 없이 switch on/off를 위해 클릭하면 1번과 같이 동작하게 됨
<br>

3. `push_state` 관련 프리퍼런스 함수 삭제
   - 마이페이지 스위치 ui를 업데이트하기 위한 함수
   - 마이페이지 진입 시 `userInfoFetch`로 `push_state`도 함께 전달해주면서 앱 내 `pushState`값을 저장할 필요없게 됨 -> 관련 함수 삭제
   - 3월 2주차 회의록에 관련 논의사항 추가함
<br>

** : android:**checked**="@{viewModel.pushState}" 와 같이 `LiveData` 타입의 `pushState` 변수가 xml에 바인딩 되어있으면 ui 업데이트를 위한 pushState 변수 값이 변경될 때마다 setOn**Checked**ChangeListener의 메서드가 호출되기 때문

## To Reviewers 📢
- 기존에 로그아웃 및 데이터 삭제 후 로그인 시 마이페이지의 스위치 ui는 서버에 저장된 `pushState`값 상관 없이 항상 off상태였습니다. 변경된 코드에서는 로그아웃 및 데이터 삭제 여부 상관없이 항상 서버에 저장된 pushState값 그대로 스위치 on/off 상태가 보여집니다!
