### PR TITLE
[feat] 아이템 수정 후 ui 업데이트 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/cart/CartItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/cart/CartItem.kt
@@ -4,7 +4,7 @@ import com.google.gson.annotations.SerializedName
 import com.hyeeyoung.wishboard.model.wish.WishItem
 
 data class CartItem(
-    val wishItem: WishItem,
+    var wishItem: WishItem,
     val cartItemInfo: CartItemInfo,
 ) {
     data class CartItemInfo(

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/cart/CartRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/cart/CartRepository.kt
@@ -5,6 +5,6 @@ import com.hyeeyoung.wishboard.model.cart.CartItem
 interface CartRepository {
     suspend fun addToCart(token: String, itemId: Long): Boolean
     suspend fun removeToCart(token: String, itemId: Long): Boolean
-    suspend fun updateCartInfo(token: String, item: CartItem): Boolean
+    suspend fun updateCartItemCount(token: String, item: CartItem): Boolean
     suspend fun fetchCartList(token: String): List<CartItem>?
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/cart/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/cart/CartRepositoryImpl.kt
@@ -22,7 +22,7 @@ class CartRepositoryImpl : CartRepository {
         }
     }
 
-    override suspend fun updateCartInfo(token: String, item: CartItem): Boolean {
+    override suspend fun updateCartItemCount(token: String, item: CartItem): Boolean {
         try {
             if (item.wishItem.id == null) return false
             val response = api.updateToCart(token, item.wishItem.id, item.cartItemInfo.count)

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/cart/CartRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/cart/CartRepositoryImpl.kt
@@ -25,7 +25,7 @@ class CartRepositoryImpl : CartRepository {
     override suspend fun updateCartItemCount(token: String, item: CartItem): Boolean {
         try {
             if (item.wishItem.id == null) return false
-            val response = api.updateToCart(token, item.wishItem.id, item.cartItemInfo.count)
+            val response = api.updateToCart(token, item.wishItem.id!!, item.cartItemInfo.count)
             if (response.isSuccessful) {
                 Log.d(TAG, "장바구니 수정 성공")
             } else {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
@@ -9,6 +9,7 @@ import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.databinding.ItemCartBinding
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.cart.CartItemButtonType
+import com.hyeeyoung.wishboard.model.wish.WishItem
 
 class CartListAdapter : ListAdapter<CartItem, RecyclerView.ViewHolder>(diffCallback) {
     private val dataSet = arrayListOf<CartItem>()
@@ -92,6 +93,11 @@ class CartListAdapter : ListAdapter<CartItem, RecyclerView.ViewHolder>(diffCallb
     //TODO 해당 코드 확인 필요
     fun updateItem(position: Int, cartItem: CartItem) {
         dataSet[position] = cartItem
+        notifyItemChanged(position)
+    }
+
+    fun updateItem(position: Int, wishItem: WishItem) {
+        dataSet[position].wishItem = wishItem
         notifyItemChanged(position)
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/CartViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/CartViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.viewModelScope
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.cart.CartItemButtonType
+import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.repository.cart.CartRepository
 import com.hyeeyoung.wishboard.util.prefs
@@ -86,6 +87,18 @@ class CartViewModel @Inject constructor(
             cartListAdapter.updateItem(position, item)
             cartList.postValue(cartListAdapter.getData() as? MutableList<CartItem>)
         }
+    }
+
+    /** 장바구니에서 아이템 수정할 경우 ui 업데이트 */
+    fun updateCartItem(position: Int, item: WishItem) {
+        cartListAdapter.updateItem(position, item)
+        cartList.postValue(cartListAdapter.getData() as? MutableList<CartItem>)
+    }
+
+    /** 장바구니에서 아이템 삭제할 경우 ui 업데이트 */
+    fun deleteCartItem(position: Int) {
+        cartListAdapter.removeItem(position)
+        cartList.postValue(cartListAdapter.getData() as? MutableList<CartItem>)
     }
 
     private fun calculateTotalPrice() {

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/CartViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/CartViewModel.kt
@@ -73,14 +73,14 @@ class CartViewModel @Inject constructor(
                     it.cartItemInfo.count -= 1
                 }
             }
-            updateCartInfo(item, position)
+            updateCartItemCount(item, position)
         }
     }
 
-    private fun updateCartInfo(item: CartItem, position: Int) {
+    private fun updateCartItemCount(item: CartItem, position: Int) {
         if (token == null) return
         viewModelScope.launch {
-            val isSuccessful = cartRepository.updateCartInfo(token, item)
+            val isSuccessful = cartRepository.updateCartItemCount(token, item)
             if (!isSuccessful) return@launch // TODO 장바구니 업데이트 실패 시 예외 처리 필요
 
             cartListAdapter.updateItem(position, item)


### PR DESCRIPTION
## What is this PR? 🔍
아이템 수정 후 ui 업데이트 구현

## Key Changes 🔑
1. `CartItem.kt` > `wishItem` 프로퍼티 val -> var로 수정
   - 상세조회에서 아이템 수정 후 `cartItem.wishItem`이 수정 가능해야하기 때문에 변경
<br>

2. `updateCartInfo -> updateCartItemCount` 로 함수명 수정
   - 업데이트 대상(count)을 명확하게 구분하기 위해 함수명을 수정함
      ```
      [CartViewModel.kt]
      updateCartItemCount() : 아이템 수량만 업데이트
      updateCartItem() : 상세조회에서 아이템 수정 후 cartItem.wishItem만 업데이트, 함수명 후보로 updateWishItem(), updateCartWishItem()도 해봤지만, CartViewModel에 맞게, 변수명 짧게 유지하기 위해 updateCartItem()으로 정함
      ```
      ```
      [CartViewModel.kt]
      // 메서드 오버로딩, 두 함수 모두 notifyItemChanged(position)을 실행해야하므로 함수명을 동일하게 유지
      updateCartItem(position: Int, cartItem: CartItem) : 실제로는 cartItem.itemCount만 업데이트, cartItem: CartItem -> count: Int로 리팩토링 예정
      updateCartItem(position: Int, wishItem: WishItem) : 실제로는 cartItem.wishItem만 업데이트
      ```
<br>

3. 아이템 수정 후 장바구니 및 폴더 디테일로 복귀 시 ui 업데이트 구현
   - 백버튼을 눌러 돌아왔을 때 변경된 아이템의 정보를 받아서 ui를 업데이트
   - 관련 코드 `findNavController().currentBackStackEntry?.savedStateHandle?`
  
## To Reviewers 📢
- 아이템 수정 후 폴더 디테일은 업데이트 되지만 백버튼으로 폴더탭, 홈탭으로 돌아왔을 때 업데이트가 반영되지 않습니다!
    - ~~폴더뷰에서 새로고침은 조금 낯선 느낌인데요,,, 현재 새로고침을 넣어야할지 고민 중입니다.~~ 폴더 새로고침 추가
- 아이템 삭제 후 장바구니에서 아이템이 삭제된 것을 확인할 수 있으나 홈으로 돌아왔을 때 새로고침을 하지 않으면 삭제된 아이템은 그대로 남아있습니다.
   - 일반등록으로 아이템 추가, 홈 > 상세조회 > 아이템 삭제할 경우 자동으로 메인화면으로 오는데, 이 경우는 업데이트 된것을 바로 확인이 가능합니다.
   - 그 외 유저가 백버튼을 눌러 홈으로 온 경우는 새로고침을 하는게 어떨까합니다. 해당 문제를 해결할 다른 아이디어가 생각난다면 즉시 수정해보겠습니다!
