### PR TITLE
[feat] 아이템 삭제 완료 후 s3에서 이미지 삭제 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/service/AWSS3Service.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/service/AWSS3Service.kt
@@ -29,6 +29,15 @@ class AWSS3Service {
         }
     }
 
+    suspend fun removeImageUrl(fileName: String) {
+        try {
+            val result = Amplify.Storage.remove(fileName)
+            Log.d(TAG, "Successfully removed ${result.key}")
+        } catch (error: StorageException) {
+            Log.e(TAG, "Remove failure", error)
+        }
+    }
+
     companion object {
         private const val TAG = "AwsS3Service"
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
@@ -24,9 +24,12 @@ class WishItemViewModel @Inject constructor(
     fun deleteWishItem() {
         if (token == null) return
         val itemId = wishItem.value?.id ?: return
-
         viewModelScope.launch {
             isCompleteDeletion.value = wishRepository.deleteWishItem(token, itemId)
+            // 아이템이 삭제 완료된 경우, s3에서도 이미지 객체 삭제
+            if (isCompleteDeletion.value == true) {
+                AWSS3Service().removeImageUrl(wishItem.value!!.image ?: return@launch)
+            }
         }
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
아이템이 삭제 완료된 경우 s3 버킷에서도 이미지 객체가 삭제되도록 구현

## Key Changes 🔑
1. s3에서 이미지 삭제하는 함수 추가
```kotlin
suspend fun removeImageUrl(fileName: String) {
        try {
            val result = Amplify.Storage.remove(fileName)
            Log.d(TAG, "Successfully removed ${result.key}")
        } catch (error: StorageException) {
            Log.e(TAG, "Remove failure", error)
        }
    }

```

2. 아이템 삭제 완료된 경우 1번 함수 실행
