### PR TITLE
[fix] 폴더 썸네일이 잘못 매칭되는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/cart/adapters/CartListAdapter.kt
@@ -75,7 +75,7 @@ class CartListAdapter : ListAdapter<CartItem, RecyclerView.ViewHolder>(diffCallb
 
     override fun getItemCount(): Int = dataSet.size
 
-    override fun getItemId(position: Int): Long = position.toLong()
+    override fun getItemId(position: Int): Long = dataSet[position].wishItem.id ?: 0
 
     fun getData(): List<CartItem> = dataSet
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -117,7 +117,7 @@ class FolderListAdapter(
 
     override fun getItemCount(): Int = dataSet.size
 
-    override fun getItemId(position: Int): Long = position.toLong()
+    override fun getItemId(position: Int): Long = dataSet[position].id ?: 0
 
     fun addData(folderItem: FolderItem) {
         dataSet.add(0, folderItem)

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/noti/adapters/NotiListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/noti/adapters/NotiListAdapter.kt
@@ -63,7 +63,7 @@ class NotiListAdapter : ListAdapter<NotiItem, RecyclerView.ViewHolder>(diffCallb
 
     override fun getItemCount(): Int = dataSet.size
 
-    override fun getItemId(position: Int): Long = position.toLong()
+    override fun getItemId(position: Int): Long = dataSet[position].itemId
 
     fun updateReadState(position: Int) {
         dataSet[position].readState = ReadStateType.READ.numValue

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/list/adapters/WishListAdapter.kt
@@ -71,7 +71,7 @@ class WishListAdapter : ListAdapter<WishItem, RecyclerView.ViewHolder>(diffCallb
 
     override fun getItemCount(): Int = dataSet.size
 
-    override fun getItemId(position: Int): Long = position.toLong()
+    override fun getItemId(position: Int): Long = dataSet[position].id ?: 0
 
     fun insertData(wishItem: WishItem) {
         dataSet.add(0, wishItem)


### PR DESCRIPTION
## What is this PR? 🔍
새폴더 또는 아이템이 없는 폴더임에도 불구하고 폴더 썸네일이 보이는 버그를 수정

## Key Changes 🔑
1. `override fun getItemId(position: Int): Long` 반환 값을 아래와 같이 고유한 id값으로 변경
   - 해결: `position.toLong()` -> `dataSet[position].wishItem.id ?: 0`
   - 설명 : 고유한 id는 뷰 자체에 대한 참조 시 사용함 -> ui 업데이트 / 삭제 작업 수행
   - 원인 : 바인딩하는 코드는 문제가 없었으나 고유한 id값이 아니였기 때문에 ui 업데이트가 제대로 이루어지지 않았던 것임

2. 다른 Adapter에서도 버그 발생 방지를 위해 `getItemId(position: Int)`의 반환값을 고유한 id값으로 변경함
