### PR TITLE
[fix] 동일이름의 폴더가 존재해도 폴더명이 수정되어 보이는 버그

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -80,18 +80,19 @@ class FolderViewModel @Inject constructor(
     }
 
     fun updateFolderName(folder: FolderItem?, position: Int?) {
-        folderRegistrationStatus.value = ProcessStatus.IN_PROGRESS
         val folderName = folderName.value?.trim()
-        if (token == null || folder?.id == null || folderName == null) return // TODO 수정 실패 예외처리 필요
+        if (token == null || folder?.id == null || position == null || folderName == null) return
+        folderRegistrationStatus.value = ProcessStatus.IN_PROGRESS
         viewModelScope.launch {
             val result = folderRepository.updateFolderName(token, folder.id, folderName)
+            if (result?.first == true) {
+                folder.name = folderName
+                folderListAdapter.updateData(position, folder)
+            }
             isCompleteUpload.value = result?.first
             isExistFolderName.value = result?.second == 409
             folderRegistrationStatus.postValue(ProcessStatus.IDLE)
         }
-
-        folder.name = folderName
-        folderListAdapter.updateData(position ?: return, folder) // TODO 수정 완료 후 UI 업데이트
     }
 
     fun deleteFolder(folder: FolderItem?, position: Int?) {


### PR DESCRIPTION
## What is this PR? 🔍
동일이름의 폴더가 존재해도 폴더명이 수정되는 것처럼 보이는 버그

## Key Changes 🔑
1. 폴더명 수정 완료 후 folderListAdapter.updateData(position, folder) 요청