### PR TITLE
[feat] 커스텀 스낵바 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/util/custom/CustomSnackbar.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/custom/CustomSnackbar.kt
@@ -1,0 +1,71 @@
+package com.hyeeyoung.wishboard.util.custom
+
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
+import androidx.databinding.DataBindingUtil
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.BaseTransientBottomBar.ANIMATION_MODE_FADE
+import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_SHORT
+import com.google.android.material.snackbar.Snackbar
+import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.databinding.SnackbarItemBinding
+
+class CustomSnackbar(
+    view: View,
+    private val message: String,
+    private val isTop: Boolean,
+    private val callback: BaseTransientBottomBar.BaseCallback<Snackbar>?
+) {
+    companion object {
+        fun make(
+            view: View,
+            message: String,
+            isTop: Boolean = true,
+            callback: BaseTransientBottomBar.BaseCallback<Snackbar>? = null
+        ) = CustomSnackbar(view, message, isTop, callback)
+    }
+
+    private val context = view.context
+    private val snackbarBinding: SnackbarItemBinding =
+        DataBindingUtil.inflate(LayoutInflater.from(context), R.layout.snackbar_item, null, false)
+    private val snackbar = Snackbar.make(view, "", LENGTH_SHORT)
+    private val snackbarLayout = snackbar.view as Snackbar.SnackbarLayout
+    private val layoutParams = LinearLayout.LayoutParams(snackbar.view.layoutParams)
+
+    init {
+        initializeView()
+        initializeData()
+    }
+
+    private fun initializeView() {
+        /* TODO 상단에서 떨어지고 올라가는 애니메이션(start: top-down, end: down-top) 적용
+            스낵바 default위치가 bottom인데, top으로 조정할 경우, 스낵바는 상단에 뜨지만 애니메이션은 여전히 하단에서 올라오고 떨어짐(defaylt)
+            임시방편 : 애니메이션을 Toast와 동일한 FADE효과(제자리에서 사라짐)로 지정 */
+        // snackbar.view.animation = AnimationUtils.loadAnimation(context, R.anim.dropdown)
+
+        snackbar.animationMode = ANIMATION_MODE_FADE
+        with(snackbarLayout) {
+            removeAllViews()
+            if (isTop) {
+                this@CustomSnackbar.layoutParams.gravity = Gravity.TOP
+                layoutParams = this@CustomSnackbar.layoutParams
+            }
+            setBackgroundColor(ContextCompat.getColor(context, android.R.color.transparent))
+            addView(snackbarBinding.root, 0)
+        }
+    }
+
+    private fun initializeData() {
+        snackbarBinding.message.text = message
+
+        if (callback == null) return
+        snackbar.addCallback(callback)
+    }
+
+    fun show() {
+        snackbar.show()
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
@@ -6,13 +6,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.DialogNewFolderAddBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -73,8 +73,7 @@ class FolderAddDialogFragment : DialogFragment() {
                     true -> R.string.folder_name_update_toast_text
                     else -> R.string.folder_add_toast_text
                 }
-                Toast.makeText(requireContext(), getString(toastMessageRes), Toast.LENGTH_SHORT)
-                    .show()
+                CustomSnackbar.make(binding.layout, getString(toastMessageRes)).show()
             }
         }
         viewModel.getRegistrationStatus().observe(this) {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -15,6 +14,7 @@ import com.hyeeyoung.wishboard.databinding.FragmentFolderBinding
 import com.hyeeyoung.wishboard.model.common.DialogButtonReplyType
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderMoreDialogButtonReplyType
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.view.common.screens.DialogListener
 import com.hyeeyoung.wishboard.view.common.screens.TwoButtonDialogFragment
@@ -69,11 +69,7 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener,
     private fun addObservers() {
         viewModel.getIsCompleteDeletion().observe(viewLifecycleOwner) { isDeleted ->
             if (isDeleted) {
-                Toast.makeText(
-                    requireContext(),
-                    getString(R.string.folder_delete_toast_text),
-                    Toast.LENGTH_SHORT
-                ).show()
+                CustomSnackbar.make(binding.layout, getString(R.string.folder_delete_toast_text)).show()
                 viewModel.resetCompleteDeletion()
             }
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.lifecycleScope
@@ -13,6 +12,7 @@ import androidx.navigation.fragment.findNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentMyBinding
 import com.hyeeyoung.wishboard.model.common.DialogButtonReplyType
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.loadProfileImage
 import com.hyeeyoung.wishboard.view.common.screens.DialogListener
@@ -73,11 +73,7 @@ class MyFragment : Fragment() {
         }
         viewModel.getCompleteDeleteUser().observe(viewLifecycleOwner) { isComplete ->
             if (isComplete == true) {
-                Toast.makeText(
-                    requireContext(),
-                    getString(R.string.my_delete_user_toast_text),
-                    Toast.LENGTH_SHORT
-                ).show()
+                CustomSnackbar.make(binding.layout, getString(R.string.my_delete_user_toast_text)).show()
                 startActivity(Intent(requireContext(), SignActivity::class.java))
                 requireActivity().finish()
             }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyProfileEditFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyProfileEditFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
 import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
@@ -16,6 +15,7 @@ import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentProfileEditBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.loadProfileImage
 import com.hyeeyoung.wishboard.util.safeLet
@@ -82,10 +82,8 @@ class MyProfileEditFragment : Fragment() {
     private fun addObservers() {
         viewModel.getCompleteUpdateUserInfo().observe(viewLifecycleOwner) { isComplete ->
             if (isComplete == true) {
-                Toast.makeText(
-                    context,
-                    getString(R.string.my_profile_edit_completion_toast_Text),
-                    Toast.LENGTH_SHORT
+                CustomSnackbar.make(
+                    binding.layout, getString(R.string.my_profile_edit_completion_toast_Text)
                 ).show()
                 findNavController().popBackStack()
             }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/sign/screens/SignInFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/sign/screens/SignInFragment.kt
@@ -13,6 +13,7 @@ import com.hyeeyoung.wishboard.view.MainActivity
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentSignInBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.showKeyboard
 import com.hyeeyoung.wishboard.viewmodel.SignViewModel
@@ -57,8 +58,7 @@ class SignInFragment : Fragment() {
                 }
                 false -> {
                     // TODO 에러케이스에 따라 에러메세지 분리 및 스낵바 커스텀 필요
-                    Snackbar.make(binding.signIn, getString(R.string.login_failed_snackbar_test), Snackbar.LENGTH_SHORT)
-                        .show()
+                    CustomSnackbar.make(binding.layout, getString(R.string.login_failed_snackbar_test), false).show()
                 }
             }
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
@@ -19,6 +18,7 @@ import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.model.wish.WishItemStatus
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
@@ -104,17 +104,15 @@ class WishBasicFragment : Fragment() {
             when (isCompleted) {
                 true -> {
                     if (isEditMode) {
-                        Toast.makeText(
-                            context,
-                            getString(R.string.wish_item_update_toast_text),
-                            Toast.LENGTH_SHORT
+                        CustomSnackbar.make(
+                            binding.layout,
+                            getString(R.string.wish_item_update_toast_text)
                         ).show()
                         moveToPrevious(WishItemStatus.MODIFIED, viewModel.getWishItem())
                     } else {
-                        Toast.makeText(
-                            context,
-                            getString(R.string.wish_item_upload_toast_text),
-                            Toast.LENGTH_SHORT
+                        CustomSnackbar.make(
+                            binding.layout,
+                            getString(R.string.wish_item_upload_toast_text)
                         ).show()
                         moveToPrevious(WishItemStatus.ADDED, null)
                     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
@@ -6,7 +6,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -17,6 +16,7 @@ import com.hyeeyoung.wishboard.databinding.FragmentWishItemDetailBinding
 import com.hyeeyoung.wishboard.model.common.DialogButtonReplyType
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.model.wish.WishItemStatus
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.common.screens.DialogListener
@@ -87,12 +87,7 @@ class WishItemDetailFragment : Fragment() {
 
         viewModel.getIsCompleteDeletion().observe(viewLifecycleOwner) { isComplete ->
             if (isComplete == true) {
-                Toast.makeText(
-                    requireContext(),
-                    getString(R.string.wish_item_deletion_toast_text),
-                    Toast.LENGTH_SHORT
-                ).show()
-
+                CustomSnackbar.make(binding.layout, getString(R.string.wish_item_deletion_toast_text)).show()
                 moveToPrevious(WishItemStatus.DELETED)
             }
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
@@ -3,16 +3,18 @@ package com.hyeeyoung.wishboard.view.wish.item.screens
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.ActivityWishLinkSharingBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.util.*
+import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
@@ -89,12 +91,8 @@ class WishLinkSharingActivity : AppCompatActivity() {
         }
         viewModel.isCompleteUpload().observe(this) { isComplete ->
             if (isComplete == true) {
-                Toast.makeText(
-                    this,
-                    getString(R.string.wish_item_registration_toast_text),
-                    Toast.LENGTH_SHORT
-                ).show()
-                finish()
+                binding.layout.visibility = View.INVISIBLE
+                showUploadCompleteSnackbar()
             }
         }
         viewModel.getRegistrationStatus().observe(this) {
@@ -117,6 +115,23 @@ class WishLinkSharingActivity : AppCompatActivity() {
                     View.VISIBLE
                 }
         }
+    }
+
+    private fun showUploadCompleteSnackbar() {
+        /* callback을 달아준 이유
+        문제 : snackbar 띄우고 바로 activity를 finish()하면 activity가 종료되면서 스낵바가 보이지 않음
+        해결 : 스낵바가 종료된 후 finish()하도록 callback 추가 */
+        CustomSnackbar.make(
+            binding.layout,
+            getString(R.string.wish_item_registration_toast_text),
+            false,
+            object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+                override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
+                    super.onDismissed(transientBottomBar, event)
+                    finish()
+                }
+            }
+        ).show()
     }
 
     companion object {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -20,17 +20,12 @@
 
         <TextView
             android:id="@+id/networkView"
+            style="@style/Widget.Snackbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/black"
-            android:fontFamily="@font/suit_r"
-            android:paddingHorizontal="@dimen/typographyDescription"
-            android:paddingVertical="@dimen/spacing20"
             android:text="@string/check_network_connection_detail"
-            android:textColor="@color/white"
-            android:textSize="@dimen/typographyBase"
-            app:layout_constraintBottom_toTopOf="@id/bottom_nav"
-            tools:visibility="gone" />
+            android:textAppearance="@style/Widget.Snackbar.TextAppearance"
+            app:layout_constraintTop_toTopOf="parent" />
 
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bottom_nav"

--- a/app/src/main/res/layout/activity_wish_link_sharing.xml
+++ b/app/src/main/res/layout/activity_wish_link_sharing.xml
@@ -20,6 +20,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/black_transparent">

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -14,6 +14,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white">

--- a/app/src/main/res/layout/fragment_my.xml
+++ b/app/src/main/res/layout/fragment_my.xml
@@ -14,6 +14,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white">

--- a/app/src/main/res/layout/fragment_profile_edit.xml
+++ b/app/src/main/res/layout/fragment_profile_edit.xml
@@ -20,6 +20,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white">

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -20,6 +20,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white">

--- a/app/src/main/res/layout/fragment_wish_item_detail.xml
+++ b/app/src/main/res/layout/fragment_wish_item_detail.xml
@@ -20,6 +20,7 @@
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/white">

--- a/app/src/main/res/layout/snackbar_item.xml
+++ b/app/src/main/res/layout/snackbar_item.xml
@@ -8,17 +8,10 @@
 
         <TextView
             android:id="@+id/message"
-            android:layout_width="wrap_content"
+            style="@style/Widget.Snackbar"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginVertical="@dimen/spacingBase"
-            android:background="@drawable/shape_border_radius_45"
-            android:backgroundTint="@color/black"
-            android:fontFamily="@font/suit_r"
-            android:paddingHorizontal="48dp"
-            android:paddingVertical="24dp"
-            android:textColor="@color/white"
-            android:textSize="@dimen/typographyBase"
+            android:textAppearance="@style/Widget.Snackbar.TextAppearance"
             tools:text="@string/wish_item_registration_toast_text" />
 
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/snackbar_item.xml
+++ b/app/src/main/res/layout/snackbar_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <TextView
+            android:id="@+id/message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginVertical="@dimen/spacingBase"
+            android:background="@drawable/shape_border_radius_45"
+            android:backgroundTint="@color/black"
+            android:fontFamily="@font/suit_r"
+            android:paddingHorizontal="48dp"
+            android:paddingVertical="24dp"
+            android:textColor="@color/white"
+            android:textSize="@dimen/typographyBase"
+            tools:text="@string/wish_item_registration_toast_text" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+</layout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -198,6 +198,26 @@
         <item name="fontFamily">@font/suit_m</item>
     </style>
 
+    <style name="Widget.Snackbar" parent="">
+        <item name="android:background">@drawable/shape_border_radius_45</item>
+        <item name="android:backgroundTint">@color/black</item>
+        <item name="android:gravity">center</item>
+        <item name="android:paddingStart">32dp</item>
+        <item name="android:paddingEnd">32dp</item>
+        <item name="android:paddingTop">24dp</item>
+        <item name="android:paddingBottom">24dp</item>
+        <item name="android:layout_marginStart">24dp</item>
+        <item name="android:layout_marginEnd">24dp</item>
+        <item name="android:layout_marginTop">@dimen/spacingBase</item>
+        <item name="android:layout_marginBottom">@dimen/spacingBase</item>
+    </style>
+
+    <style name="Widget.Snackbar.TextAppearance" parent="">
+        <item name="android:textColor">@color/white</item>
+        <item name="android:textSize">@dimen/typographyBase</item>
+        <item name="android:fontFamily">@font/suit_r</item>
+    </style>
+
     <style name="My.Section.Title" parent="">
         <item name="android:layout_marginTop">32dp</item>
         <item name="android:layout_marginStart">@dimen/spacingBase</item>


### PR DESCRIPTION
## What is this PR? 🔍
커스텀 스낵바를 구현하고 기존 `Toast -> CustomSnackbar`로 적용
## Key Changes 🔑
1. `CustomSnackbar.kt`추가
   - 커스텀 레이아웃 적용 : `SnackbarItemBinding`
   - 스낵바가 뜨는 위치를 조정
      - 기존 : 토스트가 중간에 떠서 화면 중앙을 가리는 이슈가 있었음
      - 변경 : 커스텀 토스트를 적용하면서 `isTop`이라는 인자로 스낵바가 뜨는 위치를 최상단(default), 최하단으로 적용
      - 비고 : 링크 등록, 로그인을 제외한 모든 스낵바는 최상단에 뜸
         - 링크 등록 스낵바(상품 등록 완료) : `BottomSheetDialog`로 다이얼로그 동일하게 위치를 bottom으로 설정 
         - 로그인 스낵바(로그인 실패) : 상단에 있는 로그인 입력 뷰를 가리지않도록 위치를 bottom으로 설정 

<br>

2. 모든 `Toast -> CustomSnackbar`로 변경

<br>

3. CustomSnackbar 스타일 추가 및 적용
   - 적용대상
       - `activity_main.xml` > 네트워크 연결상태뷰(실제로는 TextView이지만 Snackbar와 동일한 스타일으로 적용)
       - `item_snackbar.xml`
## To Reviewers 📢
- 스낵바 디자인은 피그마에 업로드 했습니다! 최근 댓글 참고하시면 좋을 것 같습니다!
