### PR TITLE
[delete] 이미지 수정 전용 카메라 아이콘 삭제

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -88,9 +88,6 @@ class WishBasicFragment : Fragment() {
         binding.addPhoto.setOnClickListener {
             requestStorage.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
-        binding.editPhoto.setOnClickListener {
-            requestStorage.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
-        }
         binding.folderContainer.setOnClickListener {
             findNavController().navigateSafe(R.id.action_wish_to_folder_list)
         }

--- a/app/src/main/res/layout/fragment_wish.xml
+++ b/app/src/main/res/layout/fragment_wish.xml
@@ -106,22 +106,10 @@
                         android:layout_height="80dp"
                         android:padding="@dimen/spacingBase"
                         android:src="@drawable/ic_camera"
-                        android:visibility="@{viewModel.selectedGalleryImageUri == null ? View.VISIBLE : View.INVISIBLE}"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintLeft_toLeftOf="parent"
                         app:layout_constraintRight_toRightOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
-
-                    <ImageView
-                        android:id="@+id/edit_photo"
-                        android:layout_width="80dp"
-                        android:layout_height="80dp"
-                        android:padding="@dimen/spacingBase"
-                        android:src="@drawable/ic_camera"
-                        android:visibility="@{viewModel.selectedGalleryImageUri == null ? View.GONE : View.VISIBLE}"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintRight_toRightOf="parent"
-                        tools:visibility="invisible" />
 
                 </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## What is this PR? 🔍
이미지 수정 전용 카메라 아이콘 삭제

## Key Changes 🔑
1. 아이템 일반 등록에서 갤러리 화면 진입을 위한 카메라 아이콘 2개 중 우측 하단의 카메라 아이콘을 제거
   - 기존 : 선택된 이미지가 있는 경우, 센터에 있는 카메라 아이콘은 사라지고, 우측 하단 아이콘이 보였음
   - 변경 : 이미지 선택여부 상관 없이 센터에 있는 카메라 아이콘이 항상 보임