### PR TITLE
[feat] 링크 공유에서 새폴더 추가 기능 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/adapters/FolderListAdapter.kt
@@ -27,6 +27,10 @@ class FolderListAdapter(
 
     init {
         setHasStableIds(true)
+        if (folderListViewType == FolderListViewType.SQUARE_VIEW_TYPE) {
+            dataSet.add(FolderItem()) // "폴더 추가" 뷰를 위한 더미 데이터 삽입
+            notifyItemChanged(0)
+        }
     }
 
     interface OnItemClickListener {
@@ -119,10 +123,8 @@ class FolderListAdapter(
                     Glide.with(thumbnail.context).load(url).into(thumbnail)
                 }
                 container.setOnClickListener {
-                    val unselectedPosition = selectedFolderPosition
                     selectedFolderPosition = position
-                    unselectedPosition?.let { notifyItemChanged(it) }
-                    notifyItemChanged(position)
+                    notifyItemRangeChanged(1, itemCount-1)
                     listener.onItemClick(item)
                 }
             }
@@ -190,34 +192,6 @@ class FolderListAdapter(
 
     override fun getItemId(position: Int): Long = dataSet[position].id ?: 0
 
-    fun addData(folderItem: FolderItem) {
-        dataSet.add(0, folderItem)
-        notifyItemInserted(0)
-    }
-
-    fun updateData(position: Int, folderItem: FolderItem) {
-        dataSet[position] = folderItem
-        notifyItemChanged(position)
-    }
-
-    fun deleteData(position: Int, folderItem: FolderItem) {
-        dataSet.remove(folderItem)
-        notifyItemRemoved(position)
-    }
-
-    fun setData(items: List<FolderItem>?) {
-        dataSet.clear()
-        items?.let { dataSet.addAll(it) }
-        notifyDataSetChanged()
-    }
-
-    fun setDataForSquareViewType(items: List<FolderItem>?) {
-        dataSet.clear()
-        dataSet.add(FolderItem()) // "폴더 추가" 뷰를 위한 더미 데이터 삽입
-        items?.let { dataSet.addAll(it) }
-        notifyDataSetChanged()
-    }
-
     override fun getItemViewType(position: Int): Int {
         return when (folderListViewType) {
             FolderListViewType.SQUARE_VIEW_TYPE -> {
@@ -231,6 +205,34 @@ class FolderListAdapter(
                 folderListViewType
             }
         }.ordinal
+    }
+
+    fun addData(folderItem: FolderItem) {
+        if (folderListViewType == FolderListViewType.SQUARE_VIEW_TYPE) {
+            dataSet.add(1, folderItem) // 0번 포지션인 "폴더 추가" 다음에 폴더 삽입
+            notifyItemInserted(1)
+        } else {
+            dataSet.add(0, folderItem)
+            notifyItemInserted(0)
+        }
+    }
+
+    fun updateData(position: Int, folderItem: FolderItem) {
+        dataSet[position] = folderItem
+        notifyItemChanged(position)
+    }
+
+    fun deleteData(position: Int, folderItem: FolderItem) {
+        dataSet.remove(folderItem)
+        notifyItemRemoved(position)
+    }
+
+    fun setData(items: List<FolderItem>?) {
+        if (folderListViewType != FolderListViewType.SQUARE_VIEW_TYPE) {
+            dataSet.clear()
+        }
+        items?.let { dataSet.addAll(it) }
+        notifyDataSetChanged()
     }
 
     companion object {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderUploadBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderUploadBottomDialogFragment.kt
@@ -25,6 +25,7 @@ class FolderUploadBottomDialogFragment : DialogFragment() { // TODO rename
         binding.lifecycleOwner = this@FolderUploadBottomDialogFragment
 
         viewModel.resetFolderName()
+        viewModel.resetCompleteFolderUpload()
 
         addListeners()
         addObservers()
@@ -44,8 +45,7 @@ class FolderUploadBottomDialogFragment : DialogFragment() { // TODO rename
 
     private fun addListeners() {
         binding.add.setOnClickListener {
-            // TODO 폴더 추가 요청
-            dismiss()
+            viewModel.createNewFolder()
         }
         binding.back.setOnClickListener {
             dismiss()
@@ -53,7 +53,7 @@ class FolderUploadBottomDialogFragment : DialogFragment() { // TODO rename
     }
 
     private fun addObservers() {
-        viewModel.getRegistrationStatus().observe(this) {
+        viewModel.getFolderRegistrationStatus().observe(this) {
             when (it) {
                 ProcessStatus.IDLE -> {
                     binding.loadingLottie.visibility = View.GONE
@@ -62,6 +62,11 @@ class FolderUploadBottomDialogFragment : DialogFragment() { // TODO rename
                     binding.loadingLottie.visibility = View.VISIBLE
                     binding.loadingLottie.playAnimation()
                 }
+            }
+        }
+        viewModel.isCompleteFolderUpload().observe(this) { isComplete ->
+            if (isComplete == true) {
+                dismiss()
             }
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
@@ -92,7 +92,6 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
             if (image == null) return@observe
             Glide.with(this).load(image).into(binding.itemImage)
         }
-        // TODO 폴더 추가 완료 observer 추가 및 dialog dismiss()
         viewModel.isCompleteUpload().observe(this) { isComplete ->
             if (isComplete == true) {
                 binding.layout.visibility = View.INVISIBLE

--- a/app/src/main/res/layout/dialog_bottom_folder_upload.xml
+++ b/app/src/main/res/layout/dialog_bottom_folder_upload.xml
@@ -119,7 +119,7 @@
             android:layout_marginHorizontal="@dimen/spacingBase"
             android:layout_marginTop="@dimen/spacingBase"
             android:enabled="@{viewModel.folderName.length() > 0}"
-            android:text="@{viewModel.registrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.add)}"
+            android:text="@{viewModel.folderRegistrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.add)}"
             android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
             app:layout_constraintBottom_toBottomOf="parent"
             tools:text="@string/complete" />


### PR DESCRIPTION
## What is this PR? 🔍
링크 공유에서 새폴더 추가 기능 구현

## Key Changes 🔑
1. 폴더 추가 클릭 시 `createNewFolder()`호출 및 ui 업데이트
   - 폴더 추가 api 요청
   - 추가된 폴더를 리사이클러뷰에 추가

2. FolderListAdapter.kt 코드 정리
   - init{}에서 링크공유 전용 폴더리스트에 더미데이터 삽입
      - 폴더 목록을 서버에서 가져왔을 때 같이 보여줌 -> 폴더 목록 가져옴 여부 상관없이 폴더 추가 보여짐
   - 링크 공유 전용 `setDataForSquareViewType()`, `addDataForSquareViewType()` 삭제 및 기존 `setData()`, `addData()`를  범용으로 수정

## To Reviewers 📢
- 링크 공유 아이템 등록 테스트 부탁드립니다!
