### PR TITLE
[fix] 폴더 수정 후 폴더탭 전환 반복시 마다 스낵바가 뜨는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/noti/NotiRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/noti/NotiRepository.kt
@@ -5,5 +5,5 @@ import com.hyeeyoung.wishboard.model.noti.NotiItem
 interface NotiRepository {
     suspend fun fetchNotiList(token: String): List<NotiItem>?
     suspend fun updateNotiReadState(token: String, itemId: Long)
-    suspend fun updatePushNotiSettings(token: String, isSet: Boolean)
+    suspend fun updatePushState(token: String, isSet: Boolean)
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/noti/NotiRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/noti/NotiRepositoryImpl.kt
@@ -35,9 +35,9 @@ class NotiRepositoryImpl : NotiRepository {
         }
     }
 
-    override suspend fun updatePushNotiSettings(token: String, isSet: Boolean) {
+    override suspend fun updatePushState(token: String, isSet: Boolean) {
         try {
-            val response = api.updatePushNotiSettings(token, isSet)
+            val response = api.updatePushState(token, isSet)
 
             val onOff = if (isSet) {
                 "켜기"

--- a/app/src/main/java/com/hyeeyoung/wishboard/service/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/service/RemoteService.kt
@@ -139,12 +139,6 @@ interface RemoteService {
         @Header("Authorization") token: String,
     ): Response<List<NotiItem>>?
 
-    @GET("noti/schedule")
-    suspend fun updatePushNotiSettings(
-        @Header("Authorization") token: String,
-        @Query("push") isSet: Boolean,
-    ): Response<RequestResult>
-
     @PUT("noti/{item_id}/read-state")
     suspend fun updateNotiReadState(
         @Header("Authorization") token: String,
@@ -173,6 +167,12 @@ interface RemoteService {
     @PUT("user/active")
     suspend fun deleteUserAccount(
         @Header("Authorization") token: String,
+    ): Response<RequestResult>
+
+    @PUT("user/push-state/{push}")
+    suspend fun updatePushState(
+        @Header("Authorization") token: String,
+        @Path("push") push: Boolean,
     ): Response<RequestResult>
 
     companion object {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderAddDialogFragment.kt
@@ -71,6 +71,11 @@ class FolderAddDialogFragment : DialogFragment() {
         this.listener = listener
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewModel.resetFolderData()
+    }
+
     companion object {
         const val TAG = "FolderAdditionDialogFragment"
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderFragment.kt
@@ -83,6 +83,7 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener,
                 }
                 CustomSnackbar.make(binding.layout, getString(toastMessageRes)).show()
             }
+            return@observe
         }
     }
 
@@ -120,7 +121,6 @@ class FolderFragment : Fragment(), FolderListAdapter.OnItemClickListener,
 
     /** 폴더 업로드 다이얼로그 */
     private fun showFolderUploadDialog(position: Int? = null, folderItem: FolderItem? = null) {
-        viewModel.resetFolderData()
         viewModel.setFolderInfo(position, folderItem)
         viewModel.setEditMode(folderItem != null)
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/my/screens/MyFragment.kt
@@ -52,7 +52,7 @@ class MyFragment : Fragment() {
 
     private fun addListeners() {
         binding.notiSwitch.setOnClickListener {
-            viewModel.updatePushNotiSettings()
+            viewModel.updatePushState()
         }
         binding.logout.setOnClickListener {
             showLogoutDialog()

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/MyViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/MyViewModel.kt
@@ -80,11 +80,11 @@ class MyViewModel @Inject constructor(
         }
     }
 
-    fun updatePushNotiSettings() {
+    fun updatePushState() {
         if (token == null || pushState.value == null) return
         pushState.value = !pushState.value!!
         viewModelScope.launch {
-            notiRepository.updatePushNotiSettings(token, pushState.value!!)
+            notiRepository.updatePushState(token, pushState.value!!)
         }
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
폴더 수정 후 폴더탭 전환 반복시 마다 스낵바가 뜨는 버그 수정

## Key Changes 🔑
1. 다이얼로그가 닫힐 때 마다 `viewModel.resetFolderData()` 호출
   - 스낵바는 isCompleteUpload()(폴더 업로드 성공 여부)가 true 인 경우 뜸 -> 폴더 업로드 성공 후, 스낵바가 뜨고, 다이얼로그가 닫힐 때 해당 데이터를 초기화하는 `viewModel.resetFolderData()` 호출

-𖤐## To Reviewers 📢
- 5b15d2730fbf38751f6e0f14d7c296c69d40a403 해당 커밋만 확인해주세요!
