### PR TITLE
[mod] 날짜 포맷 수정 

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/util/BindingAdapters.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/BindingAdapters.kt
@@ -42,6 +42,7 @@ fun TextView.setTimeFormat(regTime: Long?) {
             diffTime.toString() + context.getString(R.string.time_months_ago)
         }
         else -> {
+            diffTime /= TimeUtil.MONTH
             diffTime.toString() + context.getString(R.string.time_years_ago)
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/BindingAdapters.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/BindingAdapters.kt
@@ -35,10 +35,15 @@ fun TextView.setTimeFormat(regTime: Long?) {
         TimeUtil.MIN.let { diffTime /= it; diffTime } < TimeUtil.HOUR -> {
             diffTime.toString() + context.getString(R.string.time_hours_ago)
         }
-        TimeUtil.HOUR.let { diffTime /= it; diffTime } < TimeUtil.DAY -> {
-            diffTime.toString() + context.getString(R.string.time_days_ago)
+        TimeUtil.HOUR.let { diffTime /= it; diffTime } < TimeUtil.DAY_OF_MONTH -> {
+            if (diffTime < TimeUtil.DAY_OF_WEEK) {
+                diffTime.toString() + context.getString(R.string.time_days_ago)
+            } else {
+                diffTime /= TimeUtil.DAY_OF_WEEK
+                diffTime.toString() + context.getString(R.string.time_weeks_ago)
+            }
         }
-        TimeUtil.DAY.let { diffTime /= it; diffTime } < TimeUtil.MONTH -> {
+        TimeUtil.DAY_OF_MONTH.let { diffTime /= it; diffTime } < TimeUtil.MONTH -> {
             diffTime.toString() + context.getString(R.string.time_months_ago)
         }
         else -> {

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/TimeUtil.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/TimeUtil.kt
@@ -5,7 +5,8 @@ class TimeUtil {
         const val SEC = 60
         const val MIN = 60
         const val HOUR = 24
-        const val DAY = 30
+        const val DAY_OF_MONTH = 30
+        const val DAY_OF_WEEK = 7
         const val MONTH = 12
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,7 +22,7 @@
     <string name="time_hours_ago">시간 전</string>
     <string name="time_days_ago">일 전</string>
     <string name="time_weeks_ago">주 전</string>
-    <string name="time_months_ago">달 전</string>
+    <string name="time_months_ago">개월 전</string>
     <string name="time_years_ago">년 전</string>
 
     <string name="length_format">(%d/%d자)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
     <string name="time_minutes_ago">분 전</string>
     <string name="time_hours_ago">시간 전</string>
     <string name="time_days_ago">일 전</string>
+    <string name="time_weeks_ago">주 전</string>
     <string name="time_months_ago">달 전</string>
     <string name="time_years_ago">년 전</string>
 


### PR DESCRIPTION
## What is this PR? 🔍
날짜 포맷에 관련해서 버그를 수정 및 포맷추가 및 수정을 작업

## Key Changes 🔑
1. n년 전 포맷에서 n이 잘못 표기되는 버그를 수정
   - 19개월이 1년 전이 아닌 19개월로 표기되는 버그가 있었음
   - 원인 : 개월 계산에서 코드 작성하다 끝냄..😅
   - 해결 :  n년으로 바꾸기 위해 `difftime(month)`을 `MONTH(12)`로 나누기 추가
2. n주 전 포맷을 추가
3. n달 전 -> n개월 전으로 string 수정

