### PR TITLE
[feat] 아이템 디테일뷰에서 폴더 지정 기능 및 ui 구현

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/wish/WishItem.kt
@@ -8,9 +8,9 @@ import kotlinx.android.parcel.Parcelize
 @Parcelize
 data class WishItem(
     @SerializedName("folder_id")
-    val folderId: Long? = null,
+    var folderId: Long? = null,
     @SerializedName("folder_name")
-    val folderName: String? = null,
+    var folderName: String? = null,
     @SerializedName("item_id")
     val id: Long? = null,
     @SerializedName("item_img")

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/MainActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/MainActivity.kt
@@ -38,7 +38,6 @@ class MainActivity : AppCompatActivity() {
                     R.id.cart_fragment,
                     R.id.wish_fragment,
                     R.id.wish_item_detail_fragment,
-                    R.id.folder_list_fragment,
                     R.id.gallery_image_fragment,
                     R.id.profile_edit_fragment
                     -> binding.bottomNav.visibility = View.GONE

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/FolderListDialogListener.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/FolderListDialogListener.kt
@@ -1,0 +1,7 @@
+package com.hyeeyoung.wishboard.view.folder
+
+import com.hyeeyoung.wishboard.model.folder.FolderItem
+
+interface FolderListDialogListener {
+    fun onButtonClicked(folder: FolderItem)
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListBottomDialogFragment.kt
@@ -1,0 +1,78 @@
+package com.hyeeyoung.wishboard.view.folder.screens
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.viewModels
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.hyeeyoung.wishboard.databinding.DialogBottomFolderListBinding
+import com.hyeeyoung.wishboard.model.common.ProcessStatus
+import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.model.folder.FolderListViewType
+import com.hyeeyoung.wishboard.view.folder.FolderListDialogListener
+import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
+import com.hyeeyoung.wishboard.viewmodel.FolderViewModel
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class FolderListBottomDialogFragment(private val folderId: Long?) : BottomSheetDialogFragment(), FolderListAdapter.OnItemClickListener {
+    private lateinit var binding: DialogBottomFolderListBinding
+    private val viewModel: FolderViewModel by viewModels()
+    private lateinit var listener: FolderListDialogListener
+    private val folderListAdapter =
+        FolderListAdapter(FolderListViewType.HORIZONTAL_VIEW_TYPE)
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DialogBottomFolderListBinding.inflate(inflater, container, false)
+
+        initializeView()
+        addListeners()
+        addObservers()
+
+        return binding.root
+    }
+
+    private fun initializeView() {
+        val adapter = folderListAdapter
+        folderId?.let { adapter.setSelectedFolder(it) }
+        adapter.setOnItemClickListener(this@FolderListBottomDialogFragment)
+
+        binding.folderList.run {
+            this.adapter = adapter
+            itemAnimator = null
+            setItemViewCacheSize(20)
+        }
+    }
+
+    private fun addListeners() {
+        binding.close.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    private fun addObservers() {
+        viewModel.getFolderList().observe(viewLifecycleOwner) {
+            it?.let {
+                if (it.isEmpty()) return@let
+                binding.noItemView.visibility = View.GONE
+                folderListAdapter.setData(it)
+            }
+        }
+    }
+
+    fun setListener(listener: FolderListDialogListener) {
+        this.listener = listener
+    }
+
+    override fun onItemClick(item: FolderItem) {
+        listener.onButtonClicked(item)
+    }
+
+    companion object {
+        private const val TAG = "FolderListBottomDialogFragment"
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderListFragment.kt
@@ -10,12 +10,13 @@ import androidx.navigation.fragment.findNavController
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentFolderListBinding
 import com.hyeeyoung.wishboard.model.folder.FolderItem
+import com.hyeeyoung.wishboard.model.folder.FolderListViewType
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener {
+class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener { // 현재 사용되지 않는 뷰이지만, 추후 사용될 가능성이 있기 때문에 삭제하지 않음
     private lateinit var binding: FragmentFolderListBinding
     private val viewModel: WishItemRegistrationViewModel by hiltNavGraphViewModels(R.id.wish_item_registration_nav_graph)
 
@@ -32,7 +33,8 @@ class FolderListFragment : Fragment(), FolderListAdapter.OnItemClickListener {
     }
 
     private fun initializeView() {
-        val adapter = viewModel.getFolderListHorizontalAdapter()
+        val adapter = FolderListAdapter(FolderListViewType.HORIZONTAL_VIEW_TYPE)
+//        viewModel.getFolderListHorizontalAdapter()
         adapter.setOnItemClickListener(this)
         binding.folderList.run {
             this.adapter = adapter

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -16,11 +16,14 @@ import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
+import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.model.wish.WishItemStatus
 import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.safeLet
+import com.hyeeyoung.wishboard.view.folder.FolderListDialogListener
+import com.hyeeyoung.wishboard.view.folder.screens.FolderListBottomDialogFragment
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -33,6 +36,7 @@ class WishBasicFragment : Fragment() {
 
     /** 아이템 수정 여부에 따라 아이템을 update 또는 upload를 진행 (등록 및 수정 시 동일한 뷰를 사용하고 있기 때문) */
     private var isEditMode = false
+    private var folder: FolderItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,7 +93,7 @@ class WishBasicFragment : Fragment() {
             requestStorage.launch(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
         binding.folderContainer.setOnClickListener {
-            findNavController().navigateSafe(R.id.action_wish_to_folder_list)
+            showFolderListDialog()
         }
         binding.notiContainer.setOnClickListener {
             findNavController().navigateSafe(R.id.action_wish_to_noti_setting)
@@ -140,6 +144,20 @@ class WishBasicFragment : Fragment() {
                 viewModel.setSelectedGalleryImage(imageUri, imageFile)
             }
         }
+    }
+
+    private fun showFolderListDialog() {
+        val folderId = folder?.id ?: viewModel.getWishItem()?.folderId
+        val dialog = FolderListBottomDialogFragment(folderId).apply {
+            setListener(object : FolderListDialogListener {
+                override fun onButtonClicked(folder: FolderItem) {
+                    this@WishBasicFragment.folder = folder // TODO need refactoring
+                    viewModel.setFolderItem(folder)
+                    dismiss()
+                }
+            })
+        }
+        dialog.show(parentFragmentManager, "FolderListDialog")
     }
 
     /** 아이템 추가 또는 수정에 성공한 경우, UI 업데이트를 위해 변경된 아이템 정보를 이전 프래그먼트로 전달 */

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishItemDetailFragment.kt
@@ -14,6 +14,7 @@ import com.bumptech.glide.Glide
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishItemDetailBinding
 import com.hyeeyoung.wishboard.model.common.DialogButtonReplyType
+import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.model.wish.WishItemStatus
 import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
@@ -21,6 +22,8 @@ import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.common.screens.DialogListener
 import com.hyeeyoung.wishboard.view.common.screens.TwoButtonDialogFragment
+import com.hyeeyoung.wishboard.view.folder.FolderListDialogListener
+import com.hyeeyoung.wishboard.view.folder.screens.FolderListBottomDialogFragment
 import com.hyeeyoung.wishboard.viewmodel.WishItemViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -28,7 +31,8 @@ import dagger.hilt.android.AndroidEntryPoint
 class WishItemDetailFragment : Fragment() {
     private lateinit var binding: FragmentWishItemDetailBinding
     private val viewModel: WishItemViewModel by viewModels()
-    private var position: Int? = null
+    private var wishItem: WishItem? = null
+    private var position: Int? = null // TODO delete
     private var itemStatus: WishItemStatus? = null
 
     override fun onCreateView(
@@ -40,9 +44,12 @@ class WishItemDetailFragment : Fragment() {
         binding.lifecycleOwner = this@WishItemDetailFragment
 
         arguments?.let {
-            val wishItem = it[ARG_WISH_ITEM] as? WishItem
             position = it[ARG_WISH_ITEM_POSITION] as? Int
-            wishItem?.let { item -> viewModel.setWishItem(item) }
+
+            (it[ARG_WISH_ITEM] as? WishItem)?.let { item ->
+                wishItem = item
+                viewModel.setWishItem(item)
+            }
         }
 
         initializeView()
@@ -73,6 +80,9 @@ class WishItemDetailFragment : Fragment() {
                 null -> findNavController().popBackStack()
                 else -> moveToPrevious(itemStatus!!)
             }
+        }
+        binding.folderName.setOnClickListener {
+            showFolderListDialog()
         }
     }
 
@@ -135,6 +145,19 @@ class WishItemDetailFragment : Fragment() {
             })
         }
         dialog.show(parentFragmentManager, "ItemDeleteDialog")
+    }
+
+    private fun showFolderListDialog() {
+        val folderId = wishItem?.folderId
+        val dialog = FolderListBottomDialogFragment(folderId).apply {
+            setListener(object : FolderListDialogListener {
+                override fun onButtonClicked(folder: FolderItem) {
+                    viewModel.updateWishItemFolder(folder)
+                    dismiss()
+                }
+            })
+        }
+        dialog.show(parentFragmentManager, "FolderListDialog")
     }
 
     companion object {

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -7,8 +7,8 @@ import androidx.lifecycle.viewModelScope
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderListViewType
-import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.repository.folder.FolderRepository
+import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.util.prefs
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,7 +28,6 @@ class FolderViewModel @Inject constructor(
         FolderListAdapter(FolderListViewType.VERTICAL_VIEW_TYPE)
     private var folderName = MutableLiveData<String?>()
     private var folderItem: FolderItem? = null
-    private var folderPosition: Int? = null
 
     private var isCompleteUpload = MutableLiveData<Boolean?>()
     private var isCompleteDeletion = MutableLiveData<Boolean>()

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
@@ -46,7 +46,8 @@ class WishItemRegistrationViewModel @Inject constructor(
     private var itemImage = MutableLiveData<String>()
     private var itemMemo = MutableLiveData<String>()
     private var itemUrl = MutableLiveData<String>()
-    private var folderItem: FolderItem? = null
+    private var folderItem = MutableLiveData<FolderItem>()
+    private var folderName = MutableLiveData<String?>()
     private var notiType = MutableLiveData<NotiType?>()
     private var notiDate = MutableLiveData<String?>()
 
@@ -54,8 +55,6 @@ class WishItemRegistrationViewModel @Inject constructor(
     private var notiDateVal = MutableLiveData<Int>()
     private var notiHourVal = MutableLiveData<Int>()
     private var notiMinuteVal = MutableLiveData<Int>()
-
-    private var folderName = MutableLiveData<String?>()
 
     private var isEnabledSaveButton = MediatorLiveData<Boolean>()
     private var isCompleteUpload = MutableLiveData<Boolean?>()
@@ -69,8 +68,6 @@ class WishItemRegistrationViewModel @Inject constructor(
     private var selectedGalleryImageUri = MutableLiveData<Uri?>()
     private var imageFile: File? = null
 
-    private val folderListHorizontalAdapter =
-        FolderListAdapter(FolderListViewType.HORIZONTAL_VIEW_TYPE)
     private val folderListSquareAdapter =
         FolderListAdapter(FolderListViewType.SQUARE_VIEW_TYPE)
 
@@ -138,7 +135,7 @@ class WishItemRegistrationViewModel @Inject constructor(
                     price = itemPrice.value?.replace(",", "")?.toIntOrNull(),
                     url = siteUrl,
                     memo = itemMemo.value?.trim(),
-                    folderId = folderItem?.id,
+                    folderId = folderItem.value?.id,
                     notiType = notiType.value,
                     notiDate = notiDate.value
                 )
@@ -167,8 +164,8 @@ class WishItemRegistrationViewModel @Inject constructor(
                 price = itemPrice.value?.replace(",", "")?.toIntOrNull(),
                 url = itemUrl.value,
                 memo = itemMemo.value?.trim(),
-                folderId = folderItem?.id,
-                folderName = folderItem?.name, // TODO (보류) 현재 코드 상으로는 folderId만 필요한 것으로 파악되나 추후 수동등록화면에서 폴더 추가기능 도입할 경우 필요함
+                folderId = folderItem.value?.id,
+                folderName = folderItem.value?.name, // TODO (보류) 현재 코드 상으로는 folderId만 필요한 것으로 파악되나 추후 수동등록화면에서 폴더 추가기능 도입할 경우 필요함
                 notiType = notiType.value,
                 notiDate = notiDate.value
             )
@@ -199,8 +196,8 @@ class WishItemRegistrationViewModel @Inject constructor(
                 price = itemPrice.value?.replace(",", "")?.toIntOrNull(),
                 url = itemUrl.value,
                 memo = itemMemo.value?.trim(),
-                folderId = folderItem?.id ?: wishItem?.folderId,
-                folderName = folderItem?.name
+                folderId = folderItem.value?.id ?: wishItem?.folderId,
+                folderName = folderItem.value?.name
                     ?: wishItem?.folderName, // TODO (보류) 현재 코드 상으로는 folderId만 필요한 것으로 파악되나 추후 수동등록화면에서 폴더 추가기능 도입할 경우 필요함
                 notiType = notiType.value,
                 notiDate = notiDate.value
@@ -241,9 +238,7 @@ class WishItemRegistrationViewModel @Inject constructor(
                 }
             }
             withContext(Dispatchers.Main) {
-                if (items == null) return@withContext
-                folderListHorizontalAdapter.setData(items)
-                folderListSquareAdapter.setData(items)
+                items?.let { folderListSquareAdapter.setData(it) }
             }
         }
     }
@@ -374,7 +369,7 @@ class WishItemRegistrationViewModel @Inject constructor(
     }
 
     fun setFolderItem(folder: FolderItem) {
-        folderItem = folder
+        folderItem.value = folder
     }
 
     fun setNotiInfo(isNotiSwitchChecked: Boolean, notiType: NotiType?, notiDate: String?) {
@@ -425,7 +420,7 @@ class WishItemRegistrationViewModel @Inject constructor(
 
     fun getItemUrl(): LiveData<String> = itemUrl
     fun getItemMemo(): LiveData<String> = itemMemo
-    fun getFolderItem(): FolderItem? = folderItem
+    fun getFolderItem(): LiveData<FolderItem?> = folderItem
     fun getNotiType(): LiveData<NotiType?> = notiType
     fun getNotiDate(): LiveData<String?> = notiDate
 
@@ -437,7 +432,6 @@ class WishItemRegistrationViewModel @Inject constructor(
     fun getWishItem(): WishItem? = wishItem
     fun getFolderName(): LiveData<String?> = folderName
 
-    fun getFolderListHorizontalAdapter(): FolderListAdapter = folderListHorizontalAdapter
     fun getFolderListSquareAdapter(): FolderListAdapter = folderListSquareAdapter
 
     fun isEnabledSaveButton(): LiveData<Boolean> = isEnabledSaveButton

--- a/app/src/main/res/drawable/ic_check_circle.xml
+++ b/app/src/main/res/drawable/ic_check_circle.xml
@@ -1,10 +1,13 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="32dp"
-    android:height="32dp"
-    android:viewportWidth="32"
-    android:viewportHeight="32">
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
   <path
-      android:pathData="M24.9935,8.8762C25.6142,9.4249 25.6725,10.3729 25.1238,10.9935L14.6292,22.8645C14.3607,23.1682 13.9806,23.3504 13.5756,23.3693C13.1707,23.3883 12.7752,23.2426 12.4795,22.9653L6.9741,17.804C6.3697,17.2374 6.3391,16.2882 6.9057,15.6838C7.4723,15.0794 8.4215,15.0488 9.0259,15.6154L13.4045,19.7204L22.8762,9.0065C23.4249,8.3858 24.3729,8.3275 24.9935,8.8762Z"
-      android:fillColor="#ffffff"
-      android:fillType="evenOdd"/>
+      android:pathData="M4,12.7097L9.5054,17.871L20,6"
+      android:strokeLineJoin="round"
+      android:strokeWidth="3"
+      android:fillColor="#00000000"
+      android:strokeColor="#ffffff"
+      android:strokeLineCap="round"/>
 </vector>

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M18.3,5.6997L5.7,18.2997"
+      android:strokeWidth="1.6"
+      android:fillColor="#00000000"
+      android:strokeColor="#231815"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M5.7,5.6998L18.3,18.2998"
+      android:strokeWidth="1.6"
+      android:fillColor="#00000000"
+      android:strokeColor="#231815"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/layout/dialog_bottom_folder_list.xml
+++ b/app/src/main/res/layout/dialog_bottom_folder_list.xml
@@ -1,24 +1,15 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:context="com.hyeeyoung.wishboard.view.folder.screens.FolderListFragment">
-
-    <data>
-
-        <import type="android.view.View" />
-
-        <import type="androidx.navigation.Navigation" />
-
-        <variable
-            name="viewModel"
-            type="com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel" />
-    </data>
+    tools:context="com.hyeeyoung.wishboard.view.folder.screens.FolderListBottomDialogFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/white">
+        android:layout_height="wrap_content"
+        android:background="@drawable/background_dialog_top_corner"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/toolbar"
@@ -26,37 +17,33 @@
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent">
 
-            <ImageButton
-                android:id="@+id/back"
-                style="@style/Widget.Button.Icon.Navigation"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:onClick="@{(v) -> Navigation.findNavController(v).popBackStack()}"
-                android:src="@drawable/ic_back"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
             <TextView
-                style="@style/Widget.Tab.Detail.TextAppearance.Title"
+                android:id="@+id/title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/folder_list_title"
+                android:textAppearance="@style/Widget.Dialog.TextAppearance.Title"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/close"
+                style="@style/Widget.Button.Icon.Navigation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_close"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="0.5dp"
-            android:background="@color/gray_100"
-            app:layout_constraintTop_toTopOf="@id/folder_list" />
-
         <TextView
+            android:id="@+id/no_item_view"
             style="@style/Widget.TextAppearance.NoItemView.Detail"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/spacingBase"
             android:text="@string/folder_no_item_view"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -67,7 +54,9 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/folder_list"
             android:layout_width="match_parent"
-            android:layout_height="0dp"
+            android:layout_height="264dp"
+            android:clipToPadding="false"
+            android:paddingBottom="100dp"
             android:scrollbarFadeDuration="0"
             android:scrollbarSize="5dp"
             android:scrollbarThumbVertical="@android:color/darker_gray"
@@ -76,8 +65,8 @@
             app:dividerHeight="@{2f}"
             app:dividerPadding="@{0f}"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar" />
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            tools:listitem="@layout/item_folder_horizontal" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_wish_item_detail.xml
+++ b/app/src/main/res/layout/fragment_wish_item_detail.xml
@@ -85,9 +85,9 @@
                         android:id="@+id/item_image"
                         android:layout_width="match_parent"
                         android:layout_height="0dp"
-                        android:foreground="@color/semi_transparent"
                         android:background="@drawable/shape_border_radius_32"
                         android:backgroundTint="@color/gray_150"
+                        android:foreground="@color/semi_transparent"
                         android:scaleType="centerCrop"
                         app:layout_constraintDimensionRatio="3:4"
                         app:layout_constraintStart_toStartOf="parent"
@@ -136,7 +136,6 @@
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:paddingVertical="@dimen/spacing20"
                     app:layout_constraintTop_toBottomOf="@id/image_container">
 
                     <androidx.constraintlayout.widget.Guideline
@@ -153,37 +152,45 @@
                         android:orientation="vertical"
                         app:layout_constraintGuide_end="@dimen/spacingBase" />
 
+                    <androidx.constraintlayout.widget.Guideline
+                        android:id="@+id/guild_top"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal"
+                        app:layout_constraintGuide_begin="@dimen/spacing20" />
+
                     <TextView
                         android:id="@+id/folder_name"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:fontFamily="@font/suit_r"
+                        android:paddingHorizontal="@dimen/spacingBase"
+                        android:paddingVertical="@dimen/spacing10"
                         android:text="@{String.format(context.getString(R.string.go_to_folder), viewModel.wishItem.folderName == null ? context.getString(R.string.setting_folder) : viewModel.wishItem.folderName)}"
                         android:textColor="@color/gray_300"
                         android:textSize="@dimen/typographyDescription"
-                        app:layout_constraintStart_toStartOf="@id/guild_start"
-                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintBottom_toBottomOf="@id/create_at"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/create_at"
                         tools:text="상의>" />
 
-                    <!-- TODO 날짜 포맷 변경 필요 -->
                     <TextView
                         android:id="@+id/create_at"
                         android:layout_width="wrap_content"
                         android:layout_height="0dp"
                         android:layout_marginEnd="20dp"
                         android:fontFamily="@font/suit_r"
-                        app:timeFormat="@{DateFormatUtilKt.convertStrTimeToDate(viewModel.wishItem.createAt)}"
                         android:textColor="@color/gray_300"
                         android:textSize="@dimen/typographyDescription"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/guild_top"
+                        app:timeFormat="@{DateFormatUtilKt.convertStrTimeToDate(viewModel.wishItem.createAt)}"
                         tools:text="1시간 전" />
 
                     <TextView
                         android:id="@+id/item_name"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
-                        android:layout_marginTop="@dimen/spacing10"
                         android:fontFamily="@font/suit_sb"
                         android:text="@{viewModel.wishItem.name}"
                         android:textColor="@color/gray_700"

--- a/app/src/main/res/layout/item_folder_horizontal.xml
+++ b/app/src/main/res/layout/item_folder_horizontal.xml
@@ -47,7 +47,8 @@
             android:id="@+id/check"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_check"
+            android:background="@drawable/ic_check_circle"
+            android:backgroundTint="@color/green_500"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent" />

--- a/app/src/main/res/navigation/wish_item_registration_nav_graph.xml
+++ b/app/src/main/res/navigation/wish_item_registration_nav_graph.xml
@@ -14,9 +14,6 @@
             android:id="@+id/action_wish_to_gallery_image"
             app:destination="@id/gallery_image_fragment" />
         <action
-            android:id="@+id/action_wish_to_folder_list"
-            app:destination="@id/folder_list_fragment" />
-        <action
             android:id="@+id/action_wish_to_noti_setting"
             app:destination="@id/noti_setting_fragment" />
     </fragment>
@@ -26,12 +23,6 @@
         android:name="com.hyeeyoung.wishboard.view.common.screens.GalleryImageFragment"
         android:label="galleryImageFragment"
         tools:layout="@layout/fragment_gallery_image" />
-
-    <fragment
-        android:id="@+id/folder_list_fragment"
-        android:name="com.hyeeyoung.wishboard.view.folder.screens.FolderListFragment"
-        android:label="folderListFragment"
-        tools:layout="@layout/fragment_folder_list"/>
 
     <fragment
         android:id="@+id/noti_setting_fragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="folder">폴더</string>
     <string name="folder_name">폴더명</string>
     <string name="folder_name_edit">폴더명 수정</string>
-    <string name="folder_list_title">폴더 목록</string>
+    <string name="folder_list_title">폴더 지정</string>
     <string name="folder_item_count_format">%d 아이템</string>
     <string name="folder_no_item_view">앗, 폴더가 없어요!\n폴더를 추가해서 아이템을 정리해 보세요!</string>
     <string name="folder_detail_no_item_view">앗, 아이템이 없어요!\n폴더에 아이템을 담아보세요!</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -56,7 +56,7 @@
     <style name="Widget.Dialog.TextAppearance.Title" parent="">
         <item name="android:fontFamily">@font/suit_b</item>
         <item name="android:textColor">@color/black</item>
-        <item name="android:textSize">18sp</item>
+        <item name="android:textSize">@dimen/typographyBase</item>
     </style>
 
     <style name="Widget.Dialog.TextAppearance.Description" parent="">


### PR DESCRIPTION
## What is this PR? 🔍
아이템 디테일뷰에서 폴더 지정 기능 및 ui 구현

## Key Changes 🔑
1. 아이템 디테일 뷰에서 폴더 지정 기능 추가
   - `WishItemViewModel.kt` > `updateWishItemFolder()`
   - 추가폴더 업데이트를 위한 아이템 업데이트 api 요청, 배포 이후 서버에서 api 추가 시 api 변경 예정
   -  `WishItem.kt` > `folderName`, `folderId` 프로퍼티 `val -> var`로 변경
      - 폴더 업데이트를 위해 해당 프로퍼티에 값 재할당이 가능해야함 
   - `FolderListDialogListener.kt` 추가
      - 폴더지정 다이얼로그에서 선택한 폴더 정보를 받아오기 위한 인터페이스 
<br>

2. 아이템 디테일뷰, 일반 등록 뷰에서 폴더 지정 다이얼로그 띄우기
   - 기존 일반 등록 > 폴더리스트 뷰는 일반 fragment였음. -> 다이얼로그로 통일함
   - Navigation graph에서 기존 일반 등록 > 폴더리스트 뷰로 이동하는 action 제거
   - 체크 아이콘(선택된 폴더를 체크 표시)과 "X"버튼 두께를 좀 더 두껍게 변경

<br>

3. 디테일뷰 폴더명에 패딩을 주어 터치 가능 영역을 넓힘

## To Reviewers 📢
- 일반 등록과 링크공유 알림 설정 뷰도 다이얼로그 형식으로 모두 통일 예정입니다! 
- 디테일뷰와 일반 등록에서 폴더 지정 테스트 부탁드립니다!
- 슬랙에서 말씀드린 `FolderListAdapter.kt`(를 포함한 전체 어뎁터)에서 diffUtil 동작 안되는 현상은 `FolderListAdapter.kt`에 주석으로 달았고, 기존 구현 방식을 따르려고 합니다! 배포 이후에 리팩토링하면서 diffUtil이 적용되도록 수정하겠습니다!
