### PR TITLE
아이템 등록 관련 폴더 및 알림 설정 다이얼로그 ui 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderUploadBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/folder/screens/FolderUploadBottomDialogFragment.kt
@@ -1,17 +1,18 @@
 package com.hyeeyoung.wishboard.view.folder.screens
 
 import android.os.Bundle
-import android.view.*
-import androidx.fragment.app.DialogFragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
-import com.hyeeyoung.wishboard.R
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.hyeeyoung.wishboard.databinding.DialogBottomFolderUploadBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class FolderUploadBottomDialogFragment : DialogFragment() { // TODO rename
+class FolderUploadBottomDialogFragment() : BottomSheetDialogFragment() { // TODO rename
     private lateinit var binding: DialogBottomFolderUploadBinding
     private val viewModel: WishItemRegistrationViewModel by activityViewModels()
 
@@ -31,16 +32,6 @@ class FolderUploadBottomDialogFragment : DialogFragment() { // TODO rename
         addObservers()
 
         return binding.root
-    }
-
-    override fun onStart() {
-        super.onStart()
-        dialog?.window?.setLayout(
-            WindowManager.LayoutParams.MATCH_PARENT,
-            resources.getDimensionPixelSize(R.dimen.widgetBottomDialogHeightBase)
-        )
-        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
-        dialog?.window?.setGravity(Gravity.BOTTOM)
     }
 
     private fun addListeners() {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/noti/screens/NotiSettingBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/noti/screens/NotiSettingBottomDialogFragment.kt
@@ -1,19 +1,18 @@
 package com.hyeeyoung.wishboard.view.noti.screens
 
 import android.os.Bundle
-import android.view.*
-import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.activityViewModels
-import com.hyeeyoung.wishboard.R
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.hyeeyoung.wishboard.databinding.DialogBottomNotiSettingBinding
 import com.hyeeyoung.wishboard.util.*
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class NotiSettingBottomDialogFragment : DialogFragment() {
+class NotiSettingBottomDialogFragment(private val viewModel: WishItemRegistrationViewModel) : BottomSheetDialogFragment() {
     private lateinit var binding: DialogBottomNotiSettingBinding
-    private val viewModel: WishItemRegistrationViewModel by activityViewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -28,16 +27,6 @@ class NotiSettingBottomDialogFragment : DialogFragment() {
         addListeners()
 
         return binding.root
-    }
-
-    override fun onStart() {
-        super.onStart()
-        dialog?.window?.setLayout(
-            WindowManager.LayoutParams.MATCH_PARENT,
-            resources.getDimensionPixelSize(R.dimen.widgetBottomDialogHeightBase)
-        )
-        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
-        dialog?.window?.setGravity(Gravity.BOTTOM)
     }
 
     private fun initializeView() {

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -24,6 +24,7 @@ import com.hyeeyoung.wishboard.util.extension.navigateSafe
 import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.folder.FolderListDialogListener
 import com.hyeeyoung.wishboard.view.folder.screens.FolderListBottomDialogFragment
+import com.hyeeyoung.wishboard.view.noti.screens.NotiSettingBottomDialogFragment
 import com.hyeeyoung.wishboard.viewmodel.WishItemRegistrationViewModel
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -96,7 +97,7 @@ class WishBasicFragment : Fragment() {
             showFolderListDialog()
         }
         binding.notiContainer.setOnClickListener {
-            findNavController().navigateSafe(R.id.action_wish_to_noti_setting)
+            NotiSettingBottomDialogFragment(viewModel).show(parentFragmentManager, "NotiSettingDialog")
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
@@ -26,7 +26,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
-class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemClickListener, FolderListAdapter.OnNewFolderClickListener {
+class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemClickListener,
+    FolderListAdapter.OnNewFolderClickListener {
     private val viewModel: WishItemRegistrationViewModel by viewModels()
     private lateinit var binding: ActivityWishLinkSharingBinding
     private var folderAddDialog: FolderUploadBottomDialogFragment? = null
@@ -83,7 +84,10 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
             finish()
         }
         binding.notiInfoContainer.setOnClickListener {
-            NotiSettingBottomDialogFragment().show(supportFragmentManager, "NotiSettingDialog")
+            NotiSettingBottomDialogFragment(viewModel).show(
+                supportFragmentManager,
+                "NotiSettingDialog"
+            )
         }
     }
 

--- a/app/src/main/res/layout/activity_wish_link_sharing.xml
+++ b/app/src/main/res/layout/activity_wish_link_sharing.xml
@@ -28,10 +28,9 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/container"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/widgetBottomDialogHeightBase"
+            android:layout_height="wrap_content"
             android:layout_marginTop="40dp"
             android:background="@drawable/background_dialog_top_corner"
-            android:paddingBottom="@dimen/spacingBase"
             app:layout_constraintBottom_toBottomOf="parent">
 
             <ImageView
@@ -39,144 +38,150 @@
                 style="@style/Widget.Button.Icon.Navigation"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/ic_delete"
+                android:src="@drawable/ic_close"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <EditText
-                android:id="@+id/item_name"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginHorizontal="@dimen/typographyBase"
-                android:layout_marginTop="56dp"
-                android:background="@null"
-                android:ellipsize="end"
-                android:fontFamily="@font/suit_r"
-                android:gravity="center"
-                android:hint="@string/item_name_hint"
-                android:inputType="text"
-                android:maxLines="1"
-                android:onTextChanged="@{viewModel::onItemNameTextChanged}"
-                android:text="@{viewModel.itemName}"
-                android:textColor="@color/black"
-                android:textSize="@dimen/typographyBase"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:text="21SS KEILY JACHKT" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/widgetBottomDialogContentHeightBase"
+                app:layout_constraintTop_toBottomOf="@id/cancel">
 
-            <EditText
-                android:id="@+id/item_price"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacingMicro"
-                android:background="@null"
-                android:fontFamily="@font/montserrat_b"
-                android:hint="@string/price_hint"
-                android:inputType="number"
-                android:text="@{viewModel.itemPrice}"
-                android:onTextChanged="@{viewModel::onItemPriceTextChanged}"
-                android:selection="@{viewModel.itemPrice.length()}"
-                android:textAlignment="center"
-                android:textColor="@color/black"
-                android:textColorHint="@color/gray_300"
-                android:textSize="@dimen/typographyBase"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/item_name"
-                tools:text="127,000" />
+                <EditText
+                    android:id="@+id/item_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/typographyBase"
+                    android:background="@null"
+                    android:ellipsize="end"
+                    android:fontFamily="@font/suit_r"
+                    android:gravity="center"
+                    android:hint="@string/item_name_hint"
+                    android:inputType="text"
+                    android:maxLines="1"
+                    android:onTextChanged="@{viewModel::onItemNameTextChanged}"
+                    android:text="@{viewModel.itemName}"
+                    android:textColor="@color/black"
+                    android:textSize="@dimen/typographyBase"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    tools:text="21SS KEILY JACHKT" />
 
-            <LinearLayout
-                android:id="@+id/noti_info_container"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing10"
-                android:gravity="center_vertical"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/item_price">
-
-                <ImageView
+                <EditText
+                    android:id="@+id/item_price"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingHorizontal="@dimen/spacing5"
-                    android:src="@drawable/ic_noti_small" />
+                    android:layout_marginTop="@dimen/spacingMicro"
+                    android:background="@null"
+                    android:fontFamily="@font/montserrat_b"
+                    android:hint="@string/price_hint"
+                    android:inputType="number"
+                    android:text="@{viewModel.itemPrice}"
+                    android:onTextChanged="@{viewModel::onItemPriceTextChanged}"
+                    android:selection="@{viewModel.itemPrice.length()}"
+                    android:textAlignment="center"
+                    android:textColor="@color/black"
+                    android:textColorHint="@color/gray_300"
+                    android:textSize="@dimen/typographyBase"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/item_name"
+                    tools:text="127,000" />
+
+                <LinearLayout
+                    android:id="@+id/noti_info_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing10"
+                    android:gravity="center_vertical"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/item_price">
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingHorizontal="@dimen/spacing5"
+                        android:src="@drawable/ic_noti_small" />
+
+                    <TextView
+                        android:id="@+id/noti_info"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:fontFamily="@font/suit_r"
+                        android:paddingVertical="@dimen/spacing10"
+                        android:text="@{viewModel.notiType == null ? context.getString(R.string.item_registration_noti_setting_title) : String.format(context.getString(R.string.item_notification_info_short), DateFormatUtilKt.convertKoreanDate(viewModel.notiDate), context.getString(viewModel.notiType.strRes))}"
+                        android:textColor="@color/black"
+                        android:textSize="@dimen/typographyDescription"
+                        tools:text="22년 3월 8일 10시 재입고" />
+
+                    <ImageView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:onClick="@{() -> viewModel.resetNotiInfo()}"
+                        android:paddingHorizontal="@dimen/spacing5"
+                        android:paddingVertical="@dimen/spacing10"
+                        android:src="@drawable/ic_delete_circle"
+                        android:visibility="@{viewModel.notiType == null ? View.GONE : View.VISIBLE}"
+                        tools:visibility="visible" />
+                </LinearLayout>
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/folder_list"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/widgetSquareFolder"
+                    android:layout_marginStart="@dimen/spacingBase"
+                    android:layout_marginBottom="@dimen/spacing5"
+                    android:layout_weight="1"
+                    android:clipToPadding="false"
+                    android:nestedScrollingEnabled="false"
+                    android:overScrollMode="never"
+                    android:paddingEnd="6dp"
+                    app:layout_constraintBottom_toTopOf="@id/add"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/noti_info_container" />
+
+                <!-- 추후 ui 변경 시 메모가 사용될 수 있으므로 주석처리함 -->
+                <!--            <EditText-->
+                <!--                android:id="@+id/item_memo"-->
+                <!--                style="@style/Widget.EditText.Basic"-->
+                <!--                android:layout_width="match_parent"-->
+                <!--                android:layout_height="50dp"-->
+                <!--                android:layout_marginHorizontal="@dimen/spacingBase"-->
+                <!--                android:layout_marginTop="@dimen/spacing10"-->
+                <!--                android:hint="@string/memo_short_hint"-->
+                <!--                android:inputType="text"-->
+                <!--                android:textAppearance="@style/Widget.EditText.Basic.TextAppearance"-->
+                <!--                android:textSize="@dimen/typographyBase"-->
+                <!--                app:layout_constraintTop_toBottomOf="@id/noti_info_container" />-->
 
                 <TextView
-                    android:id="@+id/noti_info"
+                    android:id="@+id/add"
+                    style="@style/Widget.Button.Activate.Green"
+                    android:layout_width="match_parent"
+                    android:layout_marginHorizontal="@dimen/spacingBase"
+                    android:layout_marginBottom="@dimen/spacingBase"
+                    android:enabled="@{viewModel.itemName.length() > 0 ? true : false}"
+                    android:text="@{viewModel.registrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.wish_list_registration_button_text)}"
+                    android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    tools:text="@string/wish_list_registration_button_text" />
+
+                <com.airbnb.lottie.LottieAnimationView
+                    android:id="@+id/loading_lottie"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:fontFamily="@font/suit_r"
-                    android:paddingVertical="@dimen/spacing10"
-                    android:text="@{viewModel.notiType == null ? context.getString(R.string.item_registration_noti_setting_title) : String.format(context.getString(R.string.item_notification_info_short), DateFormatUtilKt.convertKoreanDate(viewModel.notiDate), context.getString(viewModel.notiType.strRes))}"
-                    android:textColor="@color/black"
-                    android:textSize="@dimen/typographyDescription"
-                    tools:text="22년 3월 8일 10시 재입고" />
-
-                <ImageView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:onClick="@{() -> viewModel.resetNotiInfo()}"
-                    android:paddingHorizontal="@dimen/spacing5"
-                    android:paddingVertical="@dimen/spacing10"
-                    android:src="@drawable/ic_delete_circle"
-                    android:visibility="@{viewModel.notiType == null ? View.GONE : View.VISIBLE}"
-                    tools:visibility="visible" />
-            </LinearLayout>
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/folder_list"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/widgetSquareFolder"
-                android:layout_marginStart="@dimen/spacingBase"
-                android:layout_marginBottom="@dimen/spacingBase"
-                android:layout_weight="1"
-                android:clipToPadding="false"
-                android:nestedScrollingEnabled="false"
-                android:overScrollMode="never"
-                android:paddingEnd="6dp"
-                app:layout_constraintBottom_toTopOf="@id/add"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-            <!-- 추후 ui 변경 시 메모가 사용될 수 있으므로 주석처리함 -->
-            <!--            <EditText-->
-            <!--                android:id="@+id/item_memo"-->
-            <!--                style="@style/Widget.EditText.Basic"-->
-            <!--                android:layout_width="match_parent"-->
-            <!--                android:layout_height="50dp"-->
-            <!--                android:layout_marginHorizontal="@dimen/spacingBase"-->
-            <!--                android:layout_marginTop="@dimen/spacing10"-->
-            <!--                android:hint="@string/memo_short_hint"-->
-            <!--                android:inputType="text"-->
-            <!--                android:textAppearance="@style/Widget.EditText.Basic.TextAppearance"-->
-            <!--                android:textSize="@dimen/typographyBase"-->
-            <!--                app:layout_constraintTop_toBottomOf="@id/noti_info_container" />-->
-
-            <TextView
-                android:id="@+id/add"
-                style="@style/Widget.Button.Activate.Green"
-                android:layout_width="match_parent"
-                android:layout_marginHorizontal="@dimen/spacingBase"
-                android:enabled="@{viewModel.itemName.length() > 0 ? true : false}"
-                android:text="@{viewModel.registrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.wish_list_registration_button_text)}"
-                android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
-                app:layout_constraintBottom_toBottomOf="parent"
-                tools:text="@string/wish_list_registration_button_text" />
-
-            <com.airbnb.lottie.LottieAnimationView
-                android:id="@+id/loading_lottie"
-                android:layout_width="wrap_content"
-                android:layout_height="0dp"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/add"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/add"
-                app:lottie_fileName="lottie/loading_horizontal_black.json"
-                app:lottie_imageAssetsFolder="lottie"
-                app:lottie_loop="true" />
-
+                    android:layout_height="0dp"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="@id/add"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/add"
+                    app:lottie_fileName="lottie/loading_horizontal_black.json"
+                    app:lottie_imageAssetsFolder="lottie"
+                    app:lottie_loop="true" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <ImageView

--- a/app/src/main/res/layout/dialog_bottom_folder_list.xml
+++ b/app/src/main/res/layout/dialog_bottom_folder_list.xml
@@ -54,7 +54,7 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/folder_list"
             android:layout_width="match_parent"
-            android:layout_height="264dp"
+            android:layout_height="@dimen/widgetBottomDialogContentHeightBase"
             android:clipToPadding="false"
             android:paddingBottom="100dp"
             android:scrollbarFadeDuration="0"

--- a/app/src/main/res/layout/dialog_bottom_folder_upload.xml
+++ b/app/src/main/res/layout/dialog_bottom_folder_upload.xml
@@ -20,9 +20,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/container"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/widgetBottomDialogHeightBase"
+        android:layout_height="wrap_content"
         android:background="@drawable/background_dialog_top_corner"
-        android:paddingBottom="@dimen/spacingBase"
         app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -30,15 +29,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/back"
-                style="@style/Widget.Button.Icon.Navigation"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_back"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/title"
@@ -50,92 +40,107 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/back"
+                style="@style/Widget.Button.Icon.Navigation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_close"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/folder_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@drawable/background_dialog"
-            app:layout_constraintBottom_toTopOf="@id/add"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_height="@dimen/widgetBottomDialogContentHeightBase"
             app:layout_constraintTop_toBottomOf="@id/toolbar">
 
-            <EditText
-                android:id="@+id/folder_name"
-                style="@style/Widget.EditText.Basic"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/folder_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/folder_name"
-                android:inputType="text"
-                android:maxLength="10"
-                android:maxLines="1"
-                android:onTextChanged="@{viewModel::onFolderNameTextChanged}"
-                android:text="@{viewModel.folderName}"
-                android:textAppearance="@style/Widget.EditText.Basic.TextAppearance"
+                android:background="@drawable/background_dialog"
+                app:layout_constraintBottom_toTopOf="@id/add"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-            <ImageButton
-                android:id="@+id/delete"
-                style="@style/Widget.Button"
+                <EditText
+                    android:id="@+id/folder_name"
+                    style="@style/Widget.EditText.Basic"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/folder_name"
+                    android:inputType="text"
+                    android:maxLength="10"
+                    android:maxLines="1"
+                    android:onTextChanged="@{viewModel::onFolderNameTextChanged}"
+                    android:text="@{viewModel.folderName}"
+                    android:textAppearance="@style/Widget.EditText.Basic.TextAppearance"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <ImageButton
+                    android:id="@+id/delete"
+                    style="@style/Widget.Button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="0dp"
+                    android:onClick="@{() -> viewModel.resetFolderName()}"
+                    android:padding="@dimen/spacing10"
+                    android:src="@drawable/ic_delete_circle"
+                    app:layout_constraintBottom_toBottomOf="@id/folder_name"
+                    app:layout_constraintEnd_toEndOf="@id/folder_name"
+                    app:layout_constraintTop_toTopOf="@id/folder_name" />
+
+                <TextView
+                    android:id="@+id/folder_name_length"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@{String.format(@string/length_format, viewModel.folderName.trim().length(), 10)}"
+                    android:textAppearance="@style/Widget.TextAppearance.Detail"
+                    android:textColor="@color/gray_200"
+                    app:layout_constraintEnd_toEndOf="@id/folder_name"
+                    app:layout_constraintTop_toTopOf="@id/folder_name_detail_text"
+                    tools:text="7/10글자" />
+
+                <TextView
+                    android:id="@+id/folder_name_detail_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing5"
+                    android:text="@string/folder_upload_name_already_exist_detail"
+                    android:textAppearance="@style/Widget.TextAppearance.Detail"
+                    android:visibility="@{viewModel.isExistFolderName == true ? View.VISIBLE : View.INVISIBLE}"
+                    app:layout_constraintStart_toStartOf="@id/folder_name"
+                    app:layout_constraintTop_toBottomOf="@id/folder_name" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <TextView
+                android:id="@+id/add"
+                style="@style/Widget.Button.Activate.Green"
+                android:layout_width="match_parent"
+                android:layout_margin="@dimen/spacingBase"
+                android:enabled="@{viewModel.folderName.trim().length() > 0}"
+                android:text="@{viewModel.folderRegistrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.add)}"
+                android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
+                app:layout_constraintBottom_toBottomOf="parent"
+                tools:text="@string/add" />
+
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/loading_lottie"
                 android:layout_width="wrap_content"
                 android:layout_height="0dp"
-                android:onClick="@{() -> viewModel.resetFolderName()}"
-                android:padding="@dimen/spacing10"
-                android:src="@drawable/ic_delete_circle"
-                app:layout_constraintBottom_toBottomOf="@id/folder_name"
-                app:layout_constraintEnd_toEndOf="@id/folder_name"
-                app:layout_constraintTop_toTopOf="@id/folder_name" />
-
-            <TextView
-                android:id="@+id/folder_name_length"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@{String.format(@string/length_format, viewModel.folderName.trim().length(), 10)}"
-                android:textAppearance="@style/Widget.TextAppearance.Detail"
-                android:textColor="@color/gray_200"
-                app:layout_constraintEnd_toEndOf="@id/folder_name"
-                app:layout_constraintTop_toTopOf="@id/folder_name_detail_text"
-                tools:text="7/10글자" />
-
-            <TextView
-                android:id="@+id/folder_name_detail_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing5"
-                android:text="@string/folder_upload_name_already_exist_detail"
-                android:textAppearance="@style/Widget.TextAppearance.Detail"
-                android:visibility="@{viewModel.isExistFolderName == true ? View.VISIBLE : View.INVISIBLE}"
-                app:layout_constraintStart_toStartOf="@id/folder_name"
-                app:layout_constraintTop_toBottomOf="@id/folder_name" />
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/add"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/add"
+                app:lottie_fileName="lottie/loading_horizontal_black.json"
+                app:lottie_imageAssetsFolder="lottie"
+                app:lottie_loop="true" />
 
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <TextView
-            android:id="@+id/add"
-            style="@style/Widget.Button.Activate.Green"
-            android:layout_width="match_parent"
-            android:layout_marginHorizontal="@dimen/spacingBase"
-            android:layout_marginTop="@dimen/spacingBase"
-            android:enabled="@{viewModel.folderName.trim().length() > 0}"
-            android:text="@{viewModel.folderRegistrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.add)}"
-            android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
-            app:layout_constraintBottom_toBottomOf="parent"
-            tools:text="@string/add" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/loading_lottie"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/add"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/add"
-            app:lottie_fileName="lottie/loading_horizontal_black.json"
-            app:lottie_imageAssetsFolder="lottie"
-            app:lottie_loop="true" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/dialog_bottom_noti_setting.xml
+++ b/app/src/main/res/layout/dialog_bottom_noti_setting.xml
@@ -19,9 +19,8 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/container"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/widgetBottomDialogHeightBase"
+        android:layout_height="wrap_content"
         android:background="@drawable/background_dialog_top_corner"
-        android:paddingBottom="@dimen/spacingBase"
         app:layout_constraintBottom_toBottomOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -29,15 +28,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent">
-
-            <ImageButton
-                android:id="@+id/back"
-                style="@style/Widget.Button.Icon.Navigation"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_back"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
                 android:id="@+id/title"
@@ -51,129 +41,141 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
+            <ImageButton
+                android:id="@+id/back"
+                style="@style/Widget.Button.Icon.Navigation"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_close"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/noti_container"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/spacingBase"
-            android:background="@drawable/background_dialog"
-            app:layout_constraintBottom_toTopOf="@id/noti_setting_guide"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_height="@dimen/widgetBottomDialogContentHeightBase"
             app:layout_constraintTop_toBottomOf="@id/toolbar">
-
-            <ImageView
-                android:layout_width="0dp"
-                android:layout_height="34dp"
-                android:background="@drawable/shape_border_radius_5"
-                android:backgroundTint="@color/gray_50"
-                app:layout_constraintBottom_toBottomOf="@id/noti_content_container"
-                app:layout_constraintEnd_toEndOf="@id/noti_content_container"
-                app:layout_constraintStart_toStartOf="@id/noti_content_container"
-                app:layout_constraintTop_toTopOf="@id/noti_content_container" />
-
-            <LinearLayout
-                android:id="@+id/noti_content_container"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/noti_container"
                 android:layout_width="match_parent"
-                android:layout_height="100dp"
-                app:layout_constraintBottom_toBottomOf="parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/spacingBase"
+                android:background="@drawable/background_dialog"
+                app:layout_constraintBottom_toTopOf="@id/noti_setting_guide"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent">
 
-                <NumberPicker
-                    android:id="@+id/type_picker"
+                <ImageView
                     android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="3"
-                    android:onValueChange="@{viewModel::onNotiTypeValueChanged}"
-                    android:theme="@style/AppTheme.NumberPicker"
-                    android:value="@{viewModel.notiTypeVal == null ? 0 : viewModel.notiTypeVal}" />
+                    android:layout_height="34dp"
+                    android:background="@drawable/shape_border_radius_5"
+                    android:backgroundTint="@color/gray_50"
+                    app:layout_constraintBottom_toBottomOf="@id/noti_content_container"
+                    app:layout_constraintEnd_toEndOf="@id/noti_content_container"
+                    app:layout_constraintStart_toStartOf="@id/noti_content_container"
+                    app:layout_constraintTop_toTopOf="@id/noti_content_container" />
 
-                <NumberPicker
-                    android:id="@+id/date_picker"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="3"
-                    android:onValueChange="@{viewModel::onNotiDateValueChanged}"
-                    android:theme="@style/AppTheme.NumberPicker"
-                    android:value="@{viewModel.notiDateVal == null ? 0 : viewModel.notiDateVal}"
-                    app:layout_constraintStart_toEndOf="@id/type_picker" />
-
-                <NumberPicker
-                    android:id="@+id/hour_picker"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1.2"
-                    android:onValueChange="@{viewModel::onNotiHourValueChanged}"
-                    android:theme="@style/AppTheme.NumberPicker"
-                    android:value="@{viewModel.notiHourVal == null ? 0 : viewModel.notiHourVal}"
-                    app:layout_constraintStart_toEndOf="@id/date_picker" />
-
-                <TextView
-                    android:id="@+id/colon"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center_vertical"
-                    android:fontFamily="@font/suit_b"
-                    android:text="@string/colon"
-                    android:textColor="@color/gray_700"
-                    android:textSize="@dimen/typographyBase"
+                <LinearLayout
+                    android:id="@+id/noti_content_container"
+                    android:layout_width="match_parent"
+                    android:layout_height="100dp"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/minute_picker"
-                    app:layout_constraintStart_toEndOf="@id/hour_picker"
-                    app:layout_constraintTop_toTopOf="parent" />
-
-                <NumberPicker
-                    android:id="@+id/minute_picker"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1.2"
-                    android:onValueChange="@{viewModel::onNotiMinuteValueChanged}"
-                    android:theme="@style/AppTheme.NumberPicker"
-                    android:value="@{viewModel.notiMinuteVal == null ? 0 : viewModel.notiMinuteVal}"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/colon" />
-            </LinearLayout>
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <NumberPicker
+                        android:id="@+id/type_picker"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="3"
+                        android:onValueChange="@{viewModel::onNotiTypeValueChanged}"
+                        android:theme="@style/AppTheme.NumberPicker"
+                        android:value="@{viewModel.notiTypeVal == null ? 0 : viewModel.notiTypeVal}" />
+
+                    <NumberPicker
+                        android:id="@+id/date_picker"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="3"
+                        android:onValueChange="@{viewModel::onNotiDateValueChanged}"
+                        android:theme="@style/AppTheme.NumberPicker"
+                        android:value="@{viewModel.notiDateVal == null ? 0 : viewModel.notiDateVal}"
+                        app:layout_constraintStart_toEndOf="@id/type_picker" />
+
+                    <NumberPicker
+                        android:id="@+id/hour_picker"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1.2"
+                        android:onValueChange="@{viewModel::onNotiHourValueChanged}"
+                        android:theme="@style/AppTheme.NumberPicker"
+                        android:value="@{viewModel.notiHourVal == null ? 0 : viewModel.notiHourVal}"
+                        app:layout_constraintStart_toEndOf="@id/date_picker" />
+
+                    <TextView
+                        android:id="@+id/colon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:fontFamily="@font/suit_b"
+                        android:text="@string/colon"
+                        android:textColor="@color/gray_700"
+                        android:textSize="@dimen/typographyBase"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/minute_picker"
+                        app:layout_constraintStart_toEndOf="@id/hour_picker"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <NumberPicker
+                        android:id="@+id/minute_picker"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1.2"
+                        android:onValueChange="@{viewModel::onNotiMinuteValueChanged}"
+                        android:theme="@style/AppTheme.NumberPicker"
+                        android:value="@{viewModel.notiMinuteVal == null ? 0 : viewModel.notiMinuteVal}"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/colon" />
+                </LinearLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <TextView
+                android:id="@+id/noti_setting_guide"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/spacingBase"
+                android:fontFamily="@font/suit_r"
+                android:text="@string/item_registration_noti_setting_guide"
+                android:textColor="@color/gray_300"
+                android:textSize="@dimen/typographyBaseDetail"
+                app:layout_constraintBottom_toTopOf="@id/complete"
+                app:layout_constraintStart_toStartOf="@id/complete" />
+
+            <TextView
+                android:id="@+id/complete"
+                style="@style/Widget.Button.Activate.Green"
+                android:layout_width="match_parent"
+                android:layout_margin="@dimen/spacingBase"
+                android:text="@{viewModel.registrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.complete)}"
+                android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
+                app:layout_constraintBottom_toBottomOf="parent"
+                tools:text="@string/complete" />
+
+            <com.airbnb.lottie.LottieAnimationView
+                android:id="@+id/loading_lottie"
+                android:layout_width="wrap_content"
+                android:layout_height="0dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/complete"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="@id/complete"
+                app:lottie_fileName="lottie/loading_horizontal_black.json"
+                app:lottie_imageAssetsFolder="lottie"
+                app:lottie_loop="true" />
         </androidx.constraintlayout.widget.ConstraintLayout>
-
-        <TextView
-            android:id="@+id/noti_setting_guide"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/spacingBase"
-            android:fontFamily="@font/suit_r"
-            android:text="@string/item_registration_noti_setting_guide"
-            android:textColor="@color/gray_300"
-            android:textSize="@dimen/typographyBaseDetail"
-            app:layout_constraintBottom_toTopOf="@id/complete"
-            app:layout_constraintStart_toStartOf="@id/complete" />
-
-        <TextView
-            android:id="@+id/complete"
-            style="@style/Widget.Button.Activate.Green"
-            android:layout_width="match_parent"
-            android:layout_marginHorizontal="@dimen/spacingBase"
-            android:layout_marginTop="@dimen/spacingBase"
-            android:enabled="@{viewModel.itemName.length() > 0 ? true : false}"
-            android:text="@{viewModel.registrationStatus == ProcessStatus.IN_PROGRESS ? `` : context.getString(R.string.complete)}"
-            android:textAppearance="@style/Widget.Button.Basic.TextAppearance"
-            app:layout_constraintBottom_toBottomOf="parent"
-            tools:text="@string/complete" />
-
-        <com.airbnb.lottie.LottieAnimationView
-            android:id="@+id/loading_lottie"
-            android:layout_width="wrap_content"
-            android:layout_height="0dp"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/complete"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="@id/complete"
-            app:lottie_fileName="lottie/loading_horizontal_black.json"
-            app:lottie_imageAssetsFolder="lottie"
-            app:lottie_loop="true" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/navigation/wish_item_registration_nav_graph.xml
+++ b/app/src/main/res/navigation/wish_item_registration_nav_graph.xml
@@ -13,9 +13,6 @@
         <action
             android:id="@+id/action_wish_to_gallery_image"
             app:destination="@id/gallery_image_fragment" />
-        <action
-            android:id="@+id/action_wish_to_noti_setting"
-            app:destination="@id/noti_setting_fragment" />
     </fragment>
 
     <fragment
@@ -23,10 +20,4 @@
         android:name="com.hyeeyoung.wishboard.view.common.screens.GalleryImageFragment"
         android:label="galleryImageFragment"
         tools:layout="@layout/fragment_gallery_image" />
-
-    <fragment
-        android:id="@+id/noti_setting_fragment"
-        android:name="com.hyeeyoung.wishboard.view.noti.screens.NotiSettingFragment"
-        android:label="notiSettingFragment"
-        tools:layout="@layout/fragment_noti_setting"/>
 </navigation>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -11,6 +11,7 @@
 
     <!-- Widget -->
     <dimen name="widgetBottomDialogHeightBase">312dp</dimen>
+    <dimen name="widgetBottomDialogContentHeightBase">264dp</dimen>
     <dimen name="widgetHeightBase">50dp</dimen>
     <dimen name="widgetSquareFolder">80dp</dimen>
 


### PR DESCRIPTION
## What is this PR? 🔍
아이템 등록 관련 폴더 및 알림 설정 다이얼로그 ui 수정

## Key Changes 🔑
1. 다이얼로그 툴바를 제외한 content 높이를 264dp(고정값)으로 통일
   - 적용대상 : `FolderUploadBottomDialogFragment.kt`, `NotiSettingBottomDialogFragment .kt`, `LinkSharingActivity.kt`
   - 각 레이아웃에서 id=content의 높이를 264dp로 수정
<br>

2. `FolderUploadBottomDialogFragment.kt`, `NotiSettingBottomDialogFragment .kt` 수정
   - `FolderUploadBottomDialogFragment.kt`, `NotiSettingBottomDialogFragment .kt`에서 다이얼로그 사이즈를 지정하는 onStart() 함수 제거

```kotlin
override fun onStart() {
        super.onStart()
        dialog?.window?.setLayout(
            WindowManager.LayoutParams.MATCH_PARENT,
            resources.getDimensionPixelSize(R.dimen.widgetBottomDialogHeightBase)
        )
        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
        dialog?.window?.setGravity(Gravity.BOTTOM)
    }
```
 - `DialogFragment ` -> `BottomSheetDialogFragment()`로 변경. 밑에서 다이얼로그가 드는 에니메이션을 보여주기 위함

3. 일반 등록 > 알림 설정 뷰를 fragment에서 dialog로 수정
   - 알림 버튼 클릭 시 알림설정 다이얼로그 띄우기로 변경
   - navigation graph에서 기존 알림 설정 프래그먼트로 가는 action 제거

## To Reviewers 📢
- 레이아웃에서의 변경사항이 많아보이지만 다이얼로그 높이 수정한 것이 대부분입니다! 높이를 수정하기 위해 content에 해당하는 자식뷰를 constraintLayout으로 감싸서 변경사항이 많아보이는 것임
