### PR TITLE
[fix] 다이얼로그를 빠르게 연속클릭한 경우, 다이얼로그가 두 번 이상 뜨는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishBasicFragment.kt
@@ -13,6 +13,7 @@ import androidx.hilt.navigation.fragment.hiltNavGraphViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.bumptech.glide.Glide
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.hyeeyoung.wishboard.R
 import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
@@ -39,6 +40,9 @@ class WishBasicFragment : Fragment() {
     private var isEditMode = false
     private var folder: FolderItem? = null
 
+    private lateinit var notiSettingBottomDialog: BottomSheetDialogFragment
+    private val shopLinkInputDialog = ShopLinkInputBottomDialogFragment()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -51,6 +55,8 @@ class WishBasicFragment : Fragment() {
                 viewModel.copyItemUrlToInputUrl()
             }
         }
+
+        notiSettingBottomDialog = NotiSettingBottomDialogFragment(viewModel)
     }
 
     override fun onCreateView(
@@ -99,16 +105,12 @@ class WishBasicFragment : Fragment() {
             showFolderListDialog()
         }
         binding.notiContainer.setOnClickListener {
-            NotiSettingBottomDialogFragment(viewModel).show(
-                parentFragmentManager,
-                "NotiSettingDialog"
-            )
+            if (notiSettingBottomDialog.isAdded) return@setOnClickListener
+            notiSettingBottomDialog.show(parentFragmentManager, "NotiSettingDialog")
         }
         binding.itemUrlContainer.setOnClickListener {
-            ShopLinkInputBottomDialogFragment().show(
-                parentFragmentManager,
-                "ShopLinkInputDialog"
-            )
+            if (shopLinkInputDialog.isAdded) return@setOnClickListener
+            shopLinkInputDialog.show(parentFragmentManager, "ShopLinkInputDialog")
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
@@ -9,6 +9,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.hyeeyoung.wishboard.R
@@ -30,6 +31,8 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
     FolderListAdapter.OnNewFolderClickListener {
     private val viewModel: WishItemRegistrationViewModel by viewModels()
     private lateinit var binding: ActivityWishLinkSharingBinding
+
+    private lateinit var notiSettingBottomDialog: BottomSheetDialogFragment
     private var folderAddDialog: FolderUploadBottomDialogFragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,6 +40,8 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
         binding = DataBindingUtil.setContentView(this, R.layout.activity_wish_link_sharing)
         binding.viewModel = viewModel
         binding.lifecycleOwner = this@WishLinkSharingActivity
+
+        notiSettingBottomDialog = NotiSettingBottomDialogFragment(viewModel)
 
         // 링크 공유로 데이터 받기
         val intent = intent
@@ -84,10 +89,8 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
             finish()
         }
         binding.notiInfoContainer.setOnClickListener {
-            NotiSettingBottomDialogFragment(viewModel).show(
-                supportFragmentManager,
-                "NotiSettingDialog"
-            )
+            if (notiSettingBottomDialog.isAdded) return@setOnClickListener
+            notiSettingBottomDialog.show(supportFragmentManager, "NotiSettingDialog")
         }
     }
 


### PR DESCRIPTION
## What is this PR? 🔍
링크 공유와, 일반 등록에서 다이얼로그를 빠르게 연속 클릭할 경우, 다이얼로그가 두 번 이상 뜨는 버그를 수정
## Key Changes 🔑
1. 일반 등록에서 쇼핑몰 링크 다이얼로그와 알림 설정 다이얼로그가 이미 열려있는지(isAdded) 확인 후 열려있지 않은 경우에만 다이얼로그를 show()하도록 수정
      ```kotlin
      if (notiSettingBottomDialog.isAdded) return@setOnClickListener
                  notiSettingBottomDialog.show(parentFragmentManager, "NotiSettingDialog")
      ```
   - 알림 설정 다이얼로그의 경우 파라미터로 뷰모델이 필요하기 때문에 onCreate에서 초기화
      - 전역변수로 초기화할 경우, 파라미터를 못찾아서 컴파일 에러 발생
2. 일반 등록에서 알림 설정 다이얼로그가 이미 열려있는지(isAdded) 확인 후 열려있지 않은 경우에만 다이얼로그를 show()하도록 수정

## To Reviewers 📢
- 모든 다이얼로그가 아닌 기존에 다음과 같은 형태로 띄웠던 다이얼로그 대상으로 버그가 발견되어 수정했습니다!
    ```kotlin
    binding.itemUrlContainer.setOnClickListener {
                ShopLinkInputBottomDialogFragment().show( // 클릭횟 수만큼 show()
                    parentFragmentManager,
                    "ShopLinkInputDialog"
                )
                if (shopLinkInputDialog.isAdded) return@setOnClickListener
                shopLinkInputDialog.show(parentFragmentManager, "ShopLinkInputDialog")
            }
    ```