### PR TITLE
[fix] 알림 디데이가 잘못표시되는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/util/DateFormatUtil.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/DateFormatUtil.kt
@@ -70,14 +70,15 @@ fun calculateDday(date: String): String? {
         e.printStackTrace()
         return null
     }
-    val today = Calendar.getInstance().time
-    val dday = (endDate.time - today.time) / (24 * 60 * 60 * 1000)
+
+    val today = getIgnoredTimeDays(Calendar.getInstance().time.time)
+    val dday = (today - getIgnoredTimeDays(endDate.time)) / (24 * 60 * 60 * 1000)
 
     return when {
-        dday > 0L -> { // 디데이 경과 전 -> ex) "D-6"
+        dday < 0L -> { // 디데이 경과 전 -> ex) "D-6"
             "D-${dday}"
         }
-        dday < 0L -> { // 디데이 경과 후 -> ex) "21년 1월 1일"
+        dday > 0L -> { // 디데이 경과 후 -> ex) "21년 1월 1일"
             convertDateToYMD(endDate)
         }
         else -> { // 디데이 당일 -> ex) "오늘 15시 30분"
@@ -142,4 +143,15 @@ fun convertKoreanDate(date: String?): String? {
     }
 
     return convertDateToYMD(inputDate) + " " + convertYMDHMToHourMinute(inputDate)
+}
+
+/** 시간, 분, 초 제거 */
+fun getIgnoredTimeDays(time: Long): Long {
+    return Calendar.getInstance().apply {
+        timeInMillis = time
+        set(Calendar.HOUR_OF_DAY, 0)
+        set(Calendar.MINUTE, 0)
+        set(Calendar.SECOND, 0)
+        set(Calendar.MILLISECOND, 0)
+    }.timeInMillis
 }


### PR DESCRIPTION
## What is this PR? 🔍
디테일뷰에서 알림 날짜가 다음날 자정이라도 "오늘 0시"로 디데이가 잘못 표기되는 버그
## Key Changes 🔑
1. 오늘날짜, 디데이 날짜에서 각각 시, 분, 초, 밀리초를 제거해서 오로지 날짜 차이만으로 디데이를 계산하도록 수정
   - 원인 : 기존에는 시간, 분, 초, 밀리초를 고려했기 때문에 다음날 자정이라도 현재를 기준으로 24**시간** 차이 이하인 경우에도 오늘로 표기되었던 것임
   - 해결 : 시간, 분, 초 제거해서 날짜 차이만으로 디데이 계산
    ```kotlin
    /** 시간, 분, 초 제거 */
    fun getIgnoredTimeDays(time: Long): Long {
        return Calendar.getInstance().apply {
            timeInMillis = time
            set(Calendar.HOUR_OF_DAY, 0)
            set(Calendar.MINUTE, 0)
            set(Calendar.SECOND, 0)
            set(Calendar.MILLISECOND, 0)
        }.timeInMillis
    } 
    ```
2. 가독성을 위해 디데이 계산시 오늘 날짜에서 디데이 날짜를 빼도록 수정(계산적으로는 달리진 것  없음)
   - 오늘날짜가 기준이기 때문에 오늘날짜에서 디데이를 빼는 것이 더 좋을 것 같음
   - 계산 순서가 바뀌었기 때문에 when 조건절에서 부등호 표시가 반대로 변경됨

## To Reviewers 📢
- 디테일뷰에서 다음날 자정으로 알림 설정했을 때 D-1로 뜨는 것을 확인했습니다!
