### PR TITLE
[mod] 파싱 알고리즘 개선 및 일부 사이트 전용 파싱 프로세스 추가

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/util/ParsingUtil.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/ParsingUtil.kt
@@ -1,0 +1,105 @@
+package com.hyeeyoung.wishboard.util
+
+import android.util.Log
+import com.hyeeyoung.wishboard.model.wish.WishItem
+import org.jsoup.Jsoup
+
+class ParsingUtils {
+    companion object {
+        private const val TAG = "ParsingUtils"
+        private var itemName: String? = null
+        private var itemImage: String? = null
+        private var itemPrice: Int? = null
+    }
+
+    /** 선택된 날짜에 해당하는 월간 달력을 반환 */
+    fun onBindParsingType(url: String): WishItem {
+        try {
+            when {
+                url.startsWith("https://m.musinsa.com/") || url.startsWith("https://musinsaapp.page.link/") -> {
+                    parsingForMusinsa(url)
+                }
+                url.startsWith("https://m.wconcept.co.kr/") -> {
+                    parsingForWconcept(url)
+                }
+                url.startsWith("https://m.smartstore.naver.com/") -> {
+                    parsingForNaverStore(url)
+                }
+                url.startsWith("https://www.cosstores.com/") -> {
+                    parsingForCos(url)
+                }
+                else -> {
+                    parsingForGeneral(url)
+                }
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+
+        val item = WishItem(name = itemName ?: "", image = itemImage, price = itemPrice)
+        resetData()
+        return item
+    }
+
+    /** 범용 */
+    private fun parsingForGeneral(url: String) {
+        val doc = Jsoup.connect(url).get()
+
+        itemName = doc.select("meta[property=og:title]").first()?.attr("content")
+        itemImage = doc.select("meta[property=og:image]").first()?.attr("abs:content")
+
+        val priceTags = doc.select("meta[property^=product:]")
+        if (priceTags.size > 0) {
+            val text = priceTags[0].attr("property")
+            if (text.matches(Regex(".*[pP]rice.*"))) {
+                itemPrice = priceTags[0].attr("content").replace("[^0-9]".toRegex(), "").toInt()
+            }
+        }
+    }
+
+    /** W컨셉 */
+    private fun parsingForWconcept(url: String) {
+        val doc = Jsoup.connect(url).get()
+        itemName = doc.select("meta[property=og:description]").first()?.attr("content")
+        itemImage = doc.select("meta[property=og:image]").first()?.attr("abs:content")
+        itemPrice = doc.select("meta[property=eg:salePrice]").first()?.attr("content")?.replace("[^0-9]".toRegex(), "")?.toInt()
+
+        if (itemPrice == null) {
+            itemPrice = doc.select("meta[property=eg:originalPrice]").first()?.attr("content")?.replace("[^0-9]".toRegex(), "")?.toInt()
+        }
+    }
+
+    /** 무신사 */
+    private fun parsingForMusinsa(url: String) {
+        val doc = Jsoup.connect(url).get()
+        itemName = doc.select("meta[property=og:title]").first()?.attr("content")
+        itemImage = doc.select("meta[property=og:image]").first()?.attr("abs:content")
+        itemPrice = doc.select(".product_article_price").first()?.text()?.replace("[^0-9]".toRegex(), "")?.toInt()
+    }
+
+    /** 네이버 스토어 */
+    private fun parsingForNaverStore(url: String) {
+        val doc = Jsoup.connect(url).get() ?: return
+        Log.i(TAG, "parsingForGeneral: ${doc.select("meta[property=og:title]")}")
+        itemName = doc.select("meta[property=og:title]").first()?.attr("content")
+        itemImage = doc.select("meta[property=og:image]").first()?.attr("abs:content")
+
+        val price = doc.select("._1LY7DqCnwR")
+        if (price.size <= 0) return
+        itemPrice = price[0].text().replace("[^0-9]".toRegex(), "").toInt()
+    }
+
+    /** 코스 */
+    private fun parsingForCos(url: String) {
+        val doc = Jsoup.connect(url).get()
+        itemName = doc.select("title").first()?.text()
+        itemImage = doc.select("a[href=#gallery-product-0] div img").first()?.attr("abs:src")
+        itemPrice = doc.select("#priceValue").first()?.text()?.replace("[^0-9]".toRegex(), "")?.toInt()
+    }
+
+    private fun resetData() {
+        itemName = ""
+        itemImage = null
+        itemPrice = null
+    }
+}


### PR DESCRIPTION
## What is this PR? 🔍
파싱 알고리즘 개선 및 일부 사이트 전용 파싱 프로세스 추가

## Key Changes 🔑
1. 파싱 프로세스를 따로 Util 파일로 분리
   - 기존에 사용했던 파싱 프로세스를 범용으로 두고, 아래 제시한 인기 사이트가 아닌 경우, 범용 프로세스를 실행
   - 범용의 경우 기존 프로세스에서 코드 정리만 함
1. 인기 사이트에 대해 해당 사이트 전용 파싱 프로세스를 추가
   - 무신사: 가격 못가져옴 -> 전부 가져옴
   - w컨셉: 가격 못가져오고, 이름 이상함 -> 전부 가져옴
   - 네이버 스토어: 가격 못가져옴 -> 전부 가져옴
   - cos: 아무것도 못가져옴 ->  전부 가져옴
      - 인기 사이트는 아니지만,, 이 친구는 작업하는데 5분도 안걸려서 추가함

## To Reviewers 📢
- 동일 사이트더라도 url이 모바일웹 전용, 앱 전용, pc 전용으로 나눠지고, 각 사이트별로 태그도 다릅니다.. 수작업으로는 여러울 것 같고 관련 유료api가 있다면 이용해보면 좋을 것 같습니다. 물론 다음 배포에..
