### PR TITLE
[fix] 앱이 백그라운드에서 실행되고 있지 않은 경우, 링크 공유로 아이템 등록 불가한 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/WishBoardApp.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/WishBoardApp.kt
@@ -6,12 +6,14 @@ import com.amplifyframework.AmplifyException
 import com.amplifyframework.auth.cognito.AWSCognitoAuthPlugin
 import com.amplifyframework.core.Amplify
 import com.amplifyframework.storage.s3.AWSS3StoragePlugin
+import com.hyeeyoung.wishboard.util.PreferenceUtil
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
 class WishBoardApp : Application() {
     override fun onCreate() {
         super.onCreate()
+        prefs = PreferenceUtil(applicationContext)
 
         try {
             Amplify.addPlugin(AWSCognitoAuthPlugin())
@@ -25,5 +27,6 @@ class WishBoardApp : Application() {
 
     companion object {
         private const val TAG = "WishBoardApp"
+        lateinit var prefs: PreferenceUtil
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/sign/SignRepositoryImpl.kt
@@ -1,9 +1,9 @@
 package com.hyeeyoung.wishboard.repository.sign
 
 import android.util.Log
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.user.UserInfo
 import com.hyeeyoung.wishboard.service.RemoteService
-import com.hyeeyoung.wishboard.util.prefs
 
 class SignRepositoryImpl : SignRepository {
     private val api = RemoteService.api
@@ -16,7 +16,7 @@ class SignRepositoryImpl : SignRepository {
             if (response.isSuccessful) {
                 Log.d(TAG, "회원가입 성공")
                 result?.data?.token?.let {
-                    prefs?.setUserInfo(it, email)
+                    WishBoardApp.prefs.setUserInfo(it, email)
                 }
             } else {
                 Log.e(TAG, "회원가입 실패: ${response.code()}")
@@ -35,7 +35,7 @@ class SignRepositoryImpl : SignRepository {
             if (response.isSuccessful) {
                 Log.d(TAG, "로그인 성공")
                 result?.data?.token?.let {
-                    prefs?.setUserInfo(it, email)
+                    WishBoardApp.prefs.setUserInfo(it, email)
                 }
             } else {
                 Log.e(TAG, "로그인 실패: ${response.code()}")
@@ -54,7 +54,7 @@ class SignRepositoryImpl : SignRepository {
             if (response.isSuccessful) {
                 Log.d(TAG, "이메일 인증 로그인 성공")
                 result?.data?.token?.let {
-                    prefs?.setUserInfo(it, email)
+                    WishBoardApp.prefs.setUserInfo(it, email)
                 }
                 // TODO save the pushState
             } else {

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/Util.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/Util.kt
@@ -15,8 +15,6 @@ import java.util.TimeZone
 import java.util.Locale
 import java.util.Date
 
-var prefs: PreferenceUtil? = null
-
 inline fun <T1 : Any, T2 : Any, R : Any> safeLet(p1: T1?, p2: T2?, block: (T1, T2) -> R?): R? {
     return if (p1 != null && p2 != null) block(p1, p2) else null
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/SplashActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/SplashActivity.kt
@@ -1,17 +1,19 @@
 package com.hyeeyoung.wishboard.view
 
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.lifecycleScope
 import com.hyeeyoung.wishboard.R
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.databinding.ActivitySplashBinding
-import com.hyeeyoung.wishboard.util.PreferenceUtil
-import com.hyeeyoung.wishboard.util.prefs
 import com.hyeeyoung.wishboard.view.sign.screens.SignActivity
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class SplashActivity : AppCompatActivity() {
     private lateinit var binding: ActivitySplashBinding
@@ -20,7 +22,6 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = DataBindingUtil.setContentView(this, R.layout.activity_splash)
-        prefs = PreferenceUtil(applicationContext)
 
         lifecycleScope.launch(Dispatchers.Main) {
             job = launch {
@@ -33,7 +34,7 @@ class SplashActivity : AppCompatActivity() {
 
     private fun moveToNext() {
         // TODO 유저 정보 가져오기
-        val token = prefs?.getUserToken()
+        val token = WishBoardApp.prefs.getUserToken()
         Log.d(TAG, "token : $token")
         if (token == null) {
             startActivity(Intent(this@SplashActivity, SignActivity::class.java))

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/CartViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/CartViewModel.kt
@@ -1,16 +1,12 @@
 package com.hyeeyoung.wishboard.viewmodel
 
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.cart.CartItemButtonType
 import com.hyeeyoung.wishboard.model.wish.WishItem
-import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.repository.cart.CartRepository
-import com.hyeeyoung.wishboard.util.prefs
+import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.view.cart.adapters.CartListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -22,7 +18,7 @@ import javax.inject.Inject
 class CartViewModel @Inject constructor(
     private val cartRepository: CartRepository,
 ) : ViewModel() {
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
     private val cartList = MutableLiveData<List<CartItem>?>(listOf())
     private val cartListAdapter = CartListAdapter()
     private var totalPrice = MediatorLiveData<Int>()

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/FolderViewModel.kt
@@ -4,12 +4,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderListViewType
 import com.hyeeyoung.wishboard.repository.folder.FolderRepository
 import com.hyeeyoung.wishboard.service.AWSS3Service
-import com.hyeeyoung.wishboard.util.prefs
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -21,7 +21,7 @@ import javax.inject.Inject
 class FolderViewModel @Inject constructor(
     private val folderRepository: FolderRepository,
 ) : ViewModel() {
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
 
     private val folderList = MutableLiveData<List<FolderItem>?>(listOf())
     private val folderListAdapter =
@@ -44,7 +44,7 @@ class FolderViewModel @Inject constructor(
         if (token == null) return
         viewModelScope.launch {
             var items: List<FolderItem>?
-            withContext(Dispatchers.IO){
+            withContext(Dispatchers.IO) {
                 items = folderRepository.fetchFolderList(token)
                 items?.forEach { item ->
                     item.thumbnail?.let {

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/GalleryViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/GalleryViewModel.kt
@@ -12,10 +12,10 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.repository.common.GalleryPagingDataSource
 import com.hyeeyoung.wishboard.repository.common.GalleryRepository
 import com.hyeeyoung.wishboard.util.getTimestamp
-import com.hyeeyoung.wishboard.util.prefs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
@@ -30,7 +30,7 @@ class GalleryViewModel @Inject constructor(
     private val application: Application,
     private val galleryRepository: GalleryRepository,
 ) : ViewModel() {
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
 
     private val galleryImageUris = MutableLiveData<PagingData<Uri>>()
     private var selectedGalleryImageUri = MutableLiveData<Uri?>()

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/MyViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/MyViewModel.kt
@@ -2,11 +2,11 @@ package com.hyeeyoung.wishboard.viewmodel
 
 import android.net.Uri
 import androidx.lifecycle.*
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.repository.noti.NotiRepository
 import com.hyeeyoung.wishboard.repository.user.UserRepository
 import com.hyeeyoung.wishboard.service.AWSS3Service
-import com.hyeeyoung.wishboard.util.prefs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.io.File
@@ -37,7 +37,7 @@ class MyViewModel @Inject constructor(
 
     private var profileEditStatus = MutableLiveData<ProcessStatus>()
 
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
 
     init {
         initEnabledEditCompleteButton()
@@ -47,8 +47,8 @@ class MyViewModel @Inject constructor(
         if (token == null) return
         viewModelScope.launch { // TODO 네트워크에 연결되어있지 않은 경우, 내부 저장소에서 유저 정보 가져오기
             userRepository.fetchUserInfo(token).let {
-                userEmail.value = it?.email ?: prefs?.getUserEmail()
-                userNickname.value = it?.nickname ?: prefs?.getUserNickName()
+                userEmail.value = it?.email ?: WishBoardApp.prefs.getUserEmail()
+                userNickname.value = it?.nickname ?: WishBoardApp.prefs.getUserNickName()
                 userProfileImage.value = it?.profileImage
                 pushState.value = convertIntToBooleanPushState(it?.pushState)
             }
@@ -95,7 +95,7 @@ class MyViewModel @Inject constructor(
         viewModelScope.launch {
             userRepository.registerFCMToken(token, null)
         }
-        prefs?.clearUserInfo()
+        WishBoardApp.prefs.clearUserInfo()
     }
 
     fun deleteUserAccount() {
@@ -103,7 +103,7 @@ class MyViewModel @Inject constructor(
         viewModelScope.launch {
             isCompleteUserDelete.postValue(userRepository.deleteUserAccount(token))
         }
-        prefs?.clearUserInfo()
+        WishBoardApp.prefs.clearUserInfo()
     }
 
     /** 서버에서 전달받은 push_state 값은 Int타입으로, 알림 스위치 on/off를 위해 Boolean타입으로 변경 */
@@ -145,7 +145,7 @@ class MyViewModel @Inject constructor(
     }
 
     private fun setUserInfo() {
-        prefs?.setUserNickName(inputUserNickName.value!!)
+        WishBoardApp.prefs.setUserNickName(inputUserNickName.value!!)
         userNickname.value = inputUserNickName.value
         userProfileImageFile.value?.let { file -> userProfileImage.value = file.name }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/NotiViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/NotiViewModel.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.noti.NotiItem
 import com.hyeeyoung.wishboard.model.noti.NotiListViewType
 import com.hyeeyoung.wishboard.repository.noti.NotiRepository
 import com.hyeeyoung.wishboard.service.AWSS3Service
-import com.hyeeyoung.wishboard.util.prefs
 import com.hyeeyoung.wishboard.view.noti.adapters.NotiListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -22,7 +22,7 @@ import javax.inject.Inject
 class NotiViewModel @Inject constructor(
     private val notiRepository: NotiRepository,
 ) : ViewModel() {
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
 
     private var notiList = MutableLiveData<List<NotiItem>?>(listOf())
     private var selectedNotiList = MutableLiveData<List<NotiItem>?>(listOf())

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
@@ -8,6 +8,7 @@ import android.util.Patterns
 import android.webkit.URLUtil
 import android.widget.NumberPicker
 import androidx.lifecycle.*
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.common.ProcessStatus
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.folder.FolderListViewType
@@ -18,7 +19,6 @@ import com.hyeeyoung.wishboard.repository.wish.WishRepository
 import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.util.ParsingUtils
 import com.hyeeyoung.wishboard.util.getTimestamp
-import com.hyeeyoung.wishboard.util.prefs
 import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -39,6 +39,7 @@ class WishItemRegistrationViewModel @Inject constructor(
     private val wishRepository: WishRepository,
     private val folderRepository: FolderRepository,
 ) : ViewModel() {
+    private val token = WishBoardApp.prefs.getUserToken()
     private var wishItem: WishItem? = null
     private var itemId: Long? = null
     private var itemName = MutableLiveData<String?>()
@@ -47,6 +48,7 @@ class WishItemRegistrationViewModel @Inject constructor(
     private var itemImageUrl = MutableLiveData<String?>()
     private var itemMemo = MutableLiveData<String?>()
     private var itemUrl = MutableLiveData<String?>()
+
     /** 유효하지 않은 url인 경우 또는 사이트 url 수정을 시도할 경우 원본 url을 보존하기위 위한 변수 */
     private var itemUrlInput = MutableLiveData<String?>()
     private var folderItem = MutableLiveData<FolderItem>()
@@ -73,8 +75,6 @@ class WishItemRegistrationViewModel @Inject constructor(
 
     private val folderListSquareAdapter =
         FolderListAdapter(FolderListViewType.SQUARE_VIEW_TYPE)
-
-    private val token = prefs?.getUserToken()
 
     init {
         initEnabledSaveButton()
@@ -284,7 +284,7 @@ class WishItemRegistrationViewModel @Inject constructor(
     }
 
     /** url 유효성 검증 */
-   private fun checkValidationItemUrl(url: String?): Boolean {
+    private fun checkValidationItemUrl(url: String?): Boolean {
         if (url.isNullOrBlank()) {
             return false
         }
@@ -429,7 +429,8 @@ class WishItemRegistrationViewModel @Inject constructor(
     fun setSelectedGalleryImage(imageUri: Uri, imageFile: File) {
         // 갤러리 이미지를 적용할 것이기 때문에 기존에 파싱한 이미지를 제거
         selectedGalleryImageUri.value = imageUri
-        itemImage.value = null // TODO need refactoring, 아이템 정보 파싱 후 갤러리에서 이미지 선택 하지 않아도 이전에 갤러리에서 이미지를 선택한 적이 있는 경우, 갤러리 이미지가 보이는 버그를 방지하기 위함
+        itemImage.value =
+            null // TODO need refactoring, 아이템 정보 파싱 후 갤러리에서 이미지 선택 하지 않아도 이전에 갤러리에서 이미지를 선택한 적이 있는 경우, 갤러리 이미지가 보이는 버그를 방지하기 위함
         this.imageFile = imageFile
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemViewModel.kt
@@ -4,11 +4,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.repository.wish.WishRepository
 import com.hyeeyoung.wishboard.service.AWSS3Service
-import com.hyeeyoung.wishboard.util.prefs
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import java.net.URISyntaxException
@@ -19,7 +19,7 @@ import javax.inject.Inject
 class WishItemViewModel @Inject constructor(
     private val wishRepository: WishRepository,
 ) : ViewModel() {
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
 
     private var wishItem = MutableLiveData<WishItem>()
     private var isCompleteDeletion = MutableLiveData<Boolean>()

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishListViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishListViewModel.kt
@@ -1,17 +1,17 @@
 package com.hyeeyoung.wishboard.viewmodel
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.LiveData
+import com.hyeeyoung.wishboard.WishBoardApp
 import com.hyeeyoung.wishboard.model.cart.CartStateType
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.wish.WishItem
-import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.repository.cart.CartRepository
 import com.hyeeyoung.wishboard.repository.folder.FolderRepository
 import com.hyeeyoung.wishboard.repository.wish.WishRepository
-import com.hyeeyoung.wishboard.util.prefs
+import com.hyeeyoung.wishboard.service.AWSS3Service
 import com.hyeeyoung.wishboard.view.wish.list.adapters.WishListAdapter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
@@ -25,7 +25,7 @@ class WishListViewModel @Inject constructor(
     private val cartRepository: CartRepository,
     private val folderRepository: FolderRepository,
 ) : ViewModel() {
-    private val token = prefs?.getUserToken()
+    private val token = WishBoardApp.prefs.getUserToken()
 
     private val wishList = MutableLiveData<List<WishItem>?>(listOf())
     private val wishListAdapter = WishListAdapter()


### PR DESCRIPTION
## What is this PR? 🔍
앱이 백그라운드에서 실행되고 있지 않은 경우, 링크 공유로 아이템 등록 불가한 버그 수정

## Key Changes 🔑
1.  SplashActivity -> WishBoardApp로 `prefs = PreferenceUtil(applicationContext)` 초기화 위치 변경
     - 기존에는 스플래시 엑티비티에서 prefs를 초기화시켰는데 즉, 앱을 실행시켜서 스플래시를 진입하지 않으면 유저 토큰을 불러올 수 없었던 것임
     - 애플리케이션 파일에서 prefs 변수를 초기화하고 애플리케이션의 prefs 변수로 유저토큰에 접근

## To Reviewers 📢
-  보충 설명 : SharedPreferences는 앱의 어디서든 전역적으로 사용하기 때문에 싱글톤 패턴을 사용해서 어디서든 접근 가능하게 만드는 것이 좋습니다. SharedPreferences 클래스는 앱에 있는 다른 액티비티보다 먼저 생성되어야 다른 곳에 데이터를 넘겨줄 수 있고 이러기 위해서는 Application 클래스에서 전역 변수로 SharedPreferences를 가지고 있어야 합니다~!

- 앱이 백그라운드로 실행되고 있지 않을 때도 아이템 등록되는지 확인 부탁드립니다!
