### PR TITLE
[mod] 파싱 결과값을 서버에서 전달 받도록 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/di/ServiceModule.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/di/ServiceModule.kt
@@ -1,0 +1,22 @@
+package com.hyeeyoung.wishboard.di
+
+import com.hyeeyoung.wishboard.BuildConfig
+import com.hyeeyoung.wishboard.service.RemoteService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Singleton
+
+@InstallIn(SingletonComponent::class)
+@Module
+object ServiceModule {
+    @Singleton
+    @Provides
+    fun bindRetrofitService(): RemoteService =
+        Retrofit.Builder().baseUrl(BuildConfig.BASE_URL).addConverterFactory(
+            GsonConverterFactory.create()
+        ).build().create(RemoteService::class.java)
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/BaseRequestResult.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/BaseRequestResult.kt
@@ -1,0 +1,8 @@
+package com.hyeeyoung.wishboard.model
+
+data class BaseRequestResult<T>(
+    // TODO need refactoring
+    val success: Boolean,
+    val message: String,
+    val data: T,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/wish/ItemInfo.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/wish/ItemInfo.kt
@@ -1,0 +1,12 @@
+package com.hyeeyoung.wishboard.model.wish
+
+import com.google.gson.annotations.SerializedName
+
+data class ItemInfo(
+    @SerializedName("item_img")
+    val image: String? = null,
+    @SerializedName("item_name")
+    val name: String? = null,
+    @SerializedName("item_price")
+    val price: String? = null
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepository.kt
@@ -1,5 +1,6 @@
 package com.hyeeyoung.wishboard.repository.wish
 
+import com.hyeeyoung.wishboard.model.wish.ItemInfo
 import com.hyeeyoung.wishboard.model.wish.WishItem
 
 interface WishRepository {
@@ -9,4 +10,5 @@ interface WishRepository {
     suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Boolean
     suspend fun updateFolderOfWishItem(token: String, folderId: Long, itemId: Long): Boolean
     suspend fun deleteWishItem(token: String, itemId: Long): Boolean
+    suspend fun getItemParsingInfo(site: String): ItemInfo?
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/repository/wish/WishRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.hyeeyoung.wishboard.repository.wish
 
 import android.util.Log
+import com.hyeeyoung.wishboard.model.wish.ItemInfo
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.service.RemoteService
 
@@ -99,6 +100,18 @@ class WishRepositoryImpl : WishRepository {
             e.printStackTrace()
             return false
         }
+    }
+
+    override suspend fun getItemParsingInfo(site: String): ItemInfo? {
+        return runCatching {
+            api.getItemParsingInfo(site)
+        }.fold({
+            Log.d(TAG, "아이템 파싱 성공")
+            it.body()?.data
+        }, {
+            Log.d(TAG, "아이템 파싱 실패: ${it.message}")
+            null
+        })
     }
 
     companion object {

--- a/app/src/main/java/com/hyeeyoung/wishboard/service/RemoteService.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/service/RemoteService.kt
@@ -1,12 +1,14 @@
 package com.hyeeyoung.wishboard.service
 
 import com.hyeeyoung.wishboard.BuildConfig
+import com.hyeeyoung.wishboard.model.BaseRequestResult
 import com.hyeeyoung.wishboard.model.RequestResult
 import com.hyeeyoung.wishboard.model.RequestResultData
 import com.hyeeyoung.wishboard.model.cart.CartItem
 import com.hyeeyoung.wishboard.model.folder.FolderItem
 import com.hyeeyoung.wishboard.model.noti.NotiItem
 import com.hyeeyoung.wishboard.model.user.UserInfo
+import com.hyeeyoung.wishboard.model.wish.ItemInfo
 import com.hyeeyoung.wishboard.model.wish.WishItem
 import retrofit2.Response
 import retrofit2.Retrofit
@@ -77,6 +79,11 @@ interface RemoteService {
         @Header("Authorization") token: String,
         @Path("item_id") itemId: Long
     ): Response<RequestResult>
+
+    @GET("item/parse?site=")
+    suspend fun getItemParsingInfo(
+        @Query("site") site: String
+    ): Response<BaseRequestResult<ItemInfo>?>
 
     // 장바구니
     @GET("cart")

--- a/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/view/wish/item/screens/WishLinkSharingActivity.kt
@@ -66,8 +66,6 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
     }
 
     private fun initializeView() {
-        binding.itemImage.clipToOutline = true
-
         val adapter = viewModel.getFolderListSquareAdapter()
         adapter.setOnItemClickListener(this)
         adapter.setOnNewFolderClickListener(this)
@@ -97,7 +95,7 @@ class WishLinkSharingActivity : AppCompatActivity(), FolderListAdapter.OnItemCli
     private fun addObservers() {
         viewModel.getItemImage().observe(this) { image ->
             if (image == null) return@observe
-            Glide.with(this).load(image).into(binding.itemImage)
+            Glide.with(this).load(image).circleCrop().error(R.mipmap.ic_main).into(binding.itemImage)
         }
         viewModel.isCompleteUpload().observe(this) { isComplete ->
             if (isComplete == true) {

--- a/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/viewmodel/WishItemRegistrationViewModel.kt
@@ -17,7 +17,6 @@ import com.hyeeyoung.wishboard.model.wish.WishItem
 import com.hyeeyoung.wishboard.repository.folder.FolderRepository
 import com.hyeeyoung.wishboard.repository.wish.WishRepository
 import com.hyeeyoung.wishboard.service.AWSS3Service
-import com.hyeeyoung.wishboard.util.ParsingUtils
 import com.hyeeyoung.wishboard.util.getTimestamp
 import com.hyeeyoung.wishboard.util.safeLet
 import com.hyeeyoung.wishboard.view.folder.adapters.FolderListAdapter
@@ -83,7 +82,7 @@ class WishItemRegistrationViewModel @Inject constructor(
 
     /** 오픈그래프 메타태그 파싱을 통해 아이템 정보 가져오기 */
     suspend fun getWishItemInfo(url: String) {
-        val result = ParsingUtils().onBindParsingType(url)
+        val result = wishRepository.getItemParsingInfo(url) ?: return
         itemName.postValue(result.name)
         itemPrice.postValue(result.price.toString())
         itemImage.postValue(result.image)

--- a/app/src/main/res/layout/activity_wish_link_sharing.xml
+++ b/app/src/main/res/layout/activity_wish_link_sharing.xml
@@ -190,12 +190,11 @@
             android:layout_height="80dp"
             android:layout_gravity="center_horizontal"
             android:layout_marginBottom="-40dp"
-            android:background="@drawable/shape_border_radius_40"
             android:scaleType="centerCrop"
-            android:src="@mipmap/ic_main_round"
             app:layout_constraintBottom_toTopOf="@id/container"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            tools:src="@mipmap/ic_main" />
 
         <TextView
             android:id="@+id/networkView"


### PR DESCRIPTION
## What is this PR? 🔍
파싱 결과값을 서버에서 전달 받도록 수정

## Key Changes 🔑
1. 서버에서 항상 보내주는 프로퍼티를 분리한 `BaseRequestResult.kt`추가
2. 서버에서 전달한 파싱 결과값을 받는 `ItemInfo.kt` 추가
3. 서버 요청 시 필요한 레트로핏 객체를 싱글톤 패턴으로 생성하기 위해 `ServiceModule.kt`추가
4. 파싱 결과로 가져온 이미지를 원형으로 자르고, 가져오지 못한 경우 디폴트 이미지인 앱로고를 보여주도록 수정
`Glide.with(this).load(image).circleCrop().error(R.mipmap.ic_main).into(binding.itemImage)`

## To Reviewers 📢
- 아직 머지하지 않도록 하겠습니다! 확인하시고 따봉만 달아주시면 감사하겠습니당💘
