### PR TITLE
[refactor] 커스텀 갤러리 페이징 처리 로직 리팩토링

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.0'
     implementation 'android.arch.work:work-runtime:1.0.1'
     implementation 'androidx.work:work-runtime-ktx:2.7.0'
+    implementation 'io.coil-kt:coil:2.1.0'
 
     // jsoup
     implementation 'org.jsoup:jsoup:1.14.1'
@@ -107,6 +108,9 @@ dependencies {
 
     // Calendar View
     implementation 'joda-time:joda-time:2.10.14'
+
+    // Timber
+    implementation 'com.jakewharton.timber:timber:5.0.1'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'

--- a/app/src/main/java/com/hyeeyoung/wishboard/data/model/GalleryData.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/model/GalleryData.kt
@@ -1,0 +1,8 @@
+package com.hyeeyoung.wishboard.data.model
+
+import android.net.Uri
+
+data class GalleryData(
+    val id: Long,
+    val uri: Uri,
+)

--- a/app/src/main/java/com/hyeeyoung/wishboard/data/repositories/GalleryRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/repositories/GalleryRepositoryImpl.kt
@@ -1,57 +1,14 @@
 package com.hyeeyoung.wishboard.data.repositories
 
-import android.content.ContentResolver
-import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
+import android.content.Context
+import com.hyeeyoung.wishboard.data.datasources.GalleryPagingDataSource
 import com.hyeeyoung.wishboard.domain.repositories.GalleryRepository
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
-import kotlin.math.min
 
 // TODO rename ~~Impl class name
-class GalleryRepositoryImpl @Inject constructor(): GalleryRepository {
-    private var imageUris = mutableListOf<Uri>()
-    private var pageIndex: Int = 0
-
-    override suspend fun fetchGalleryImage(
-        startPagingIndex: Int,
-        contentResolver: ContentResolver
-    ): Pair<List<Uri>, Int> {
-        if (startPagingIndex == 0) {
-            val uriExternal =
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    MediaStore.Images.Media.getContentUri(
-                        MediaStore.VOLUME_EXTERNAL
-                    )
-                } else {
-                    MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-                }
-
-            val projection = arrayOf(MediaStore.Images.Media._ID)
-            val sortOrder = "${MediaStore.Images.Media.DATE_TAKEN} DESC"
-            contentResolver.query(
-                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                projection, null, null, sortOrder
-            )?.use { cursor ->
-                var imageId: Long
-                while (cursor.moveToNext()) {
-                    imageId = cursor.getLong(cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID))
-                    val uriImage = Uri.withAppendedPath(uriExternal, "" + imageId)
-                    imageUris.add(uriImage)
-                }
-                cursor.close()
-            }
-
-            pageIndex = PAGE_SIZE
-            return Pair(imageUris.subList(0, min(pageIndex, imageUris.size)), min(pageIndex, imageUris.size))
-        } else {
-            val startIndex = pageIndex
-            pageIndex += PAGE_SIZE
-            return Pair(imageUris.subList(startIndex, min(pageIndex, imageUris.size)), min(pageIndex, imageUris.size))
-        }
-    }
-    companion object {
-        private const val TAG = "GalleryRepositoryImpl"
-        private const val PAGE_SIZE = 10
-    }
+class GalleryRepositoryImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : GalleryRepository {
+    override fun galleryPagingSource() = GalleryPagingDataSource(context)
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/domain/repositories/GalleryRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/domain/repositories/GalleryRepository.kt
@@ -1,8 +1,7 @@
 package com.hyeeyoung.wishboard.domain.repositories
 
-import android.content.ContentResolver
-import android.net.Uri
+import com.hyeeyoung.wishboard.data.datasources.GalleryPagingDataSource
 
 interface GalleryRepository {
-    suspend fun fetchGalleryImage(startPagingIndex: Int, contentResolver: ContentResolver): Pair<List<Uri>, Int>
+    fun galleryPagingSource(): GalleryPagingDataSource
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/common/adapters/GalleryPagingAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/common/adapters/GalleryPagingAdapter.kt
@@ -1,34 +1,25 @@
 package com.hyeeyoung.wishboard.presentation.common.adapters
 
-import android.content.Context
 import android.net.Uri
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.bumptech.glide.Glide
+import coil.load
+import com.hyeeyoung.wishboard.data.model.GalleryData
 import com.hyeeyoung.wishboard.databinding.ItemGalleryImageBinding
 
-class GalleryPagingAdapter(
-    private val context: Context
-) : PagingDataAdapter<Uri, RecyclerView.ViewHolder>(diffCallback) {
-    private lateinit var listener: OnItemClickListener
-
-    interface OnItemClickListener {
-        fun onItemClick(imageUri: Uri)
-    }
-
-    fun setOnItemClickListener(listener: OnItemClickListener) {
-        this.listener = listener
-    }
-
-    inner class ViewHolder(private val binding: ItemGalleryImageBinding) :
+class GalleryPagingAdapter(private val onItemClick: (Uri) -> Unit) :
+    PagingDataAdapter<GalleryData, RecyclerView.ViewHolder>(diffCallback) {
+    class ViewHolder(private val binding: ItemGalleryImageBinding) :
         RecyclerView.ViewHolder(binding.root) {
-        fun bind(imageUri: Uri) {
-            Glide.with(context).load(imageUri).into(binding.itemImage)
-            binding.container.setOnClickListener {
-                listener.onItemClick(imageUri)
+        fun bind(imageUri: GalleryData, onItemClick: (Uri) -> Unit) {
+            with(binding) {
+                itemImage.load(imageUri.uri)
+                container.setOnClickListener {
+                    onItemClick(imageUri.uri)
+                }
             }
         }
     }
@@ -46,27 +37,23 @@ class GalleryPagingAdapter(
     override fun onBindViewHolder(viewHolder: RecyclerView.ViewHolder, position: Int) {
         val imageUri = getItem(position) ?: return
         when (viewHolder) {
-            is ViewHolder -> viewHolder.bind(imageUri)
+            is ViewHolder -> viewHolder.bind(imageUri, onItemClick)
         }
     }
 
     companion object {
         private const val TAG = "GalleryPagingAdapter"
 
-        private val diffCallback = object : DiffUtil.ItemCallback<Uri>() {
+        private val diffCallback = object : DiffUtil.ItemCallback<GalleryData>() {
             override fun areItemsTheSame(
-                oldItem: Uri,
-                newItem: Uri
+                oldItem: GalleryData,
+                newItem: GalleryData
             ): Boolean =
-                if (oldItem is Uri && newItem is Uri) {
-                    oldItem == newItem
-                } else {
-                    false
-                }
+                oldItem.id == newItem.id
 
             override fun areContentsTheSame(
-                oldItem: Uri,
-                newItem: Uri
+                oldItem: GalleryData,
+                newItem: GalleryData
             ): Boolean = oldItem == newItem
         }
     }

--- a/app/src/main/res/layout/fragment_gallery_image.xml
+++ b/app/src/main/res/layout/fragment_gallery_image.xml
@@ -58,8 +58,12 @@
             android:id="@+id/image_list"
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar" />
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            app:spanCount="3"
+            tools:itemCount="20"
+            tools:listitem="@layout/item_gallery_image" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
## What is this PR? 🔍
커스텀 갤러리 페이징 처리 로직을 리팩토링 했습니다!

## Key Changes 🔑
1. 사용자가 스크롤 할 때마다 갤리리 사진을 전부 다 가져와서 `subList()`로 페이지 단위의 이미지리스트를 return -> 사용자가 스크롤 할 떄마다 해당 위치에서 페이지 사이즈만큼 이미지 리스트를 return
   - 기존에도 페이징을 적용하긴 했지만, 로직 자체가 잘못되었기 떄문에 위와 같이 변경함
2. 갤러리 이미지 가져오는 함수를 `GalleryRepositoryImpl` -> `GalleryPagingDataSource`로 이동 
3. 갤러리 이미지 로드 시 `Glide` -> `coil`로 라이브러리 변경 (Glide보다 보일러플레이트 코드가 줄어들음, 로드 시 상대적으로 가볍게 로드됨)
4. `GalleryPagingAdpater()` 리팩토링

## To Reviewers 📢
- 갤러리 사진을 가져올 때 페이지 단위로 사진을 가져오게되면 첫 로드 속도를 단축시킬 수 있습니다. 예를 들어 사진 10000장이 있다고 가정했을 때 페이징을 적용하지 않고 모든 이미지를 한번에 로드할 경우, 10000장을 전부 가져올 때 까지 로딩 시간이 딜레이됩니다. 그런데 10000장의 사진을 스크롤 할 떄마다 페이지 단위 30으로 분할해서 가져올 경우, 30장을 가져오는 속도가 걸리게 됩니다.
