### PR TITLE
[fix] 삭제된 아이템을 수정 시도할 수 있는 버그를 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/data/repositories/WishRepositoryImpl.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/repositories/WishRepositoryImpl.kt
@@ -54,18 +54,18 @@ class WishRepositoryImpl @Inject constructor(private val wishItemService: WishIt
         }
     }
 
-    override suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Boolean {
-        try {
+    override suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Pair<Boolean, Int>? {
+        return try {
             val response = wishItemService.updateToWishItem(token, itemId, wishItem)
             if (response.isSuccessful) {
                 Log.d(TAG, "아이템 수정 성공")
             } else {
                 Log.e(TAG, "아이템 수정 실패: ${response.code()}")
             }
-            return response.isSuccessful
+            Pair(response.isSuccessful, response.code())
         } catch (e: Exception) {
             e.printStackTrace()
-            return false
+            null
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/domain/repositories/WishRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/domain/repositories/WishRepository.kt
@@ -7,7 +7,7 @@ interface WishRepository {
     suspend fun fetchWishList(token: String): List<WishItem>?
     suspend fun fetchLatestWishItem(token: String): WishItem?
     suspend fun uploadWishItem(token: String, wishItem: WishItem): Boolean
-    suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Boolean
+    suspend fun updateWishItem(token: String, itemId: Long, wishItem: WishItem): Pair<Boolean, Int>?
     suspend fun updateFolderOfWishItem(token: String, folderId: Long, itemId: Long): Boolean
     suspend fun deleteWishItem(token: String, itemId: Long): Boolean
     suspend fun getItemParsingInfo(site: String): ItemInfo?

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/common/screens/OneButtonDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/common/screens/OneButtonDialogFragment.kt
@@ -1,0 +1,45 @@
+package com.hyeeyoung.wishboard.presentation.common.screens
+
+import android.os.Bundle
+import android.view.*
+import androidx.fragment.app.DialogFragment
+import com.hyeeyoung.wishboard.databinding.DialogOneButtonBinding
+
+class OneButtonDialogFragment(
+    private val title: String,
+    private val description: String?
+) : DialogFragment() {
+    private lateinit var binding: DialogOneButtonBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        binding = DialogOneButtonBinding.inflate(inflater, container, false)
+        val dialog = dialog
+        dialog?.window?.requestFeature(Window.FEATURE_NO_TITLE)
+
+        binding.title.text = title
+        binding.description.text = description
+
+        addListener()
+
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.WRAP_CONTENT
+        )
+        dialog?.window?.setBackgroundDrawableResource(android.R.color.transparent)
+    }
+
+    private fun addListener() {
+        binding.yes.setOnClickListener {
+            dismiss()
+        }
+    }
+}

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wishitem/screens/WishBasicFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wishitem/screens/WishBasicFragment.kt
@@ -19,6 +19,7 @@ import com.hyeeyoung.wishboard.databinding.FragmentWishBinding
 import com.hyeeyoung.wishboard.presentation.common.types.ProcessStatus
 import com.hyeeyoung.wishboard.data.model.folder.FolderItem
 import com.hyeeyoung.wishboard.data.model.wish.WishItem
+import com.hyeeyoung.wishboard.presentation.common.screens.OneButtonDialogFragment
 import com.hyeeyoung.wishboard.presentation.wishitem.WishItemStatus
 import com.hyeeyoung.wishboard.util.custom.CustomSnackbar
 import com.hyeeyoung.wishboard.util.extension.navigateSafe
@@ -181,6 +182,18 @@ class WishBasicFragment : Fragment() {
                 it.clear()
             }
         }
+
+        viewModel.isShownItemNonUpdateDialog.observe(viewLifecycleOwner) { isShown ->
+            if (isShown == true) showItemNonUpdateDialog()
+        }
+    }
+
+    private fun showItemNonUpdateDialog() {
+        val dialog = OneButtonDialogFragment(
+            getString(R.string.item_non_update_dialog_title),
+            getString(R.string.item_non_update_dialog_description)
+        )
+        dialog.show(parentFragmentManager, "ItemNonUpdateDialog")
     }
 
     private fun showFolderListDialog() {

--- a/app/src/main/res/layout/dialog_one_button.xml
+++ b/app/src/main/res/layout/dialog_one_button.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".presentation.common.screens.TwoButtonDialogFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            style="@style/Widget.Dialog"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="@string/item_non_update_dialog_title"
+                android:textAppearance="@style/Widget.Dialog.TextAppearance.Title"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/description"
+                style="@style/Widget.Dialog.Description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/Widget.Dialog.TextAppearance.Description"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/title"
+                tools:text="@string/item_non_update_dialog_description" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="0.5dp"
+                android:background="@color/gray_100"
+                app:layout_constraintTop_toTopOf="@id/yes" />
+
+            <Button
+                android:id="@+id/yes"
+                style="@style/Widget.Button.Dialog"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="32dp"
+                android:textAppearance="@style/Widget.Button.Dialog.TextAppearance"
+                app:layout_constraintTop_toBottomOf="@id/description"
+                android:text="@string/confirm" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,9 @@
     <string name="item_registration_noti_setting_guide">30분 전에 상품 일정을 알려드려요! 시간은 30분 단위로 설정할 수 있어요.</string>
     <string name="wish_list_registration_button_text">위시리스트에 추가</string>
 
+    <string name="item_non_update_dialog_description">앗, 삭제된 아이템은 수정할 수 없어요.\n홈탭에서 새로고침을 시도해 주세요!</string>
+    <string name="item_non_update_dialog_title">아이템 수정 오류</string>
+
     <!-- Detail -->
     <string name="go_to_folder">%s></string>
     <string name="setting_folder">폴더를 지정해 보세요!</string>


### PR DESCRIPTION
## What is this PR? 🔍
삭제된 아이템을 수정 시도할 수 있는 버그를 수정했습니다.

## Key Changes 🔑
1. 다음과 같이 삭제된 아이템을 수정 시도하려는 경우, 아이템 수정 불가 다이얼로그를 띄워줍니다.
<img width="199" alt="image" src="https://user-images.githubusercontent.com/48701368/185771861-373990d1-e872-4fe3-9da1-6450c69f7add.png">

1.1 `WishItemRegistrationViewModel.kt`
삭제된 아이템을 수정 시도할 경우, 서버에서는 code값으로 수정된 아이템 없음(404)를 보내주고 있으며 404여부에 따라 _isShownItemNonUpdateDialog.value를 설정하고 있습니다!

```kotlin
_isShownItemNonUpdateDialog.value = result?.second == 404
```
<br>

1.2 `WishBasicFragment.kt`
프래그먼트에서는 isShownItemNonUpdateDialog.value가 true인 경우에만 다이얼로그를 띄웁니다!
```kotlin
viewModel.isShownItemNonUpdateDialog.observe(viewLifecycleOwner) { isShown ->
            if (isShown == true) showItemNonUpdateDialog()
        }
```
## To Reviewers 📢
- 특정 폴더에서 아이템 삭제 후 홉탭으로 돌아왔을 때 새로고침을 적용하지 않은 상황에서 해당 아이템을 수정 시도할 경우, 해당 다이얼로그가 띄워집니다.
