### PR TITLE
[fix] 프로필 편집뷰에서 이미지 변경 시 마이페이지에서 이미지가 업데이트 되지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/data/model/user/UserInfo.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/model/user/UserInfo.kt
@@ -6,7 +6,7 @@ data class UserInfo( // TODO need refactoring
     var email: String? = null,
     var password: String? = null,
     var nickname: String? = null,
-    @SerializedName("profile_img")
+    @SerializedName("profile_img_url")
     var profileImage: String? = null,
     @SerializedName("push_state")
     val pushState: Int? = null,

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/my/MyViewModel.kt
@@ -152,10 +152,10 @@ class MyViewModel @Inject constructor(
         isCorrectedEmail.value = null
     }
 
+    /** 유저 프로필 업데이트 이후 로컬에 닉네임을 저장 */
+    // TODO 함수명 변경
     private fun setUserInfo() {
         WishBoardApp.prefs.setUserNickName(inputUserNickName.value!!)
-        userNickname.value = inputUserNickName.value
-        userProfileImageFile.value?.let { file -> userProfileImage.value = file.name }
     }
 
     fun setSelectedUserProfileImage(imageUri: Uri, imageFile: File) {
@@ -217,6 +217,5 @@ class MyViewModel @Inject constructor(
     fun getCompleteUpdateUserInfo(): LiveData<Boolean?> = isCompleteUpdateUserInfo
     fun getCompleteDeleteUser(): LiveData<Boolean?> = isCompleteUserDelete
     fun isValidNicknameFormat(): LiveData<Boolean?> = isValidNicknameFormat
-
     fun getProfileEditStatus(): LiveData<ProcessStatus> = profileEditStatus
 }


### PR DESCRIPTION
## What is this PR? 🔍
프로필 편집뷰에서 이미지 변경 시 마이페이지에서 이미지가 업데이트 되지 않는 버그 수정
## Key Changes 🔑
1. 유저정보 데이텉 클래스를 전달받을 때 profile_img -> profile_img_url로 보내주고 있었음. 노션 명세서 및 안드 데이터 클래스 변경 완!