### PR TITLE
[fix] 로그인 화면 진입하자마자 로그인 실패 스낵바가 뜨는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/sign/screens/SignInFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/sign/screens/SignInFragment.kt
@@ -55,10 +55,10 @@ class SignInFragment : Fragment() {
                     startActivity(Intent(requireContext(), MainActivity::class.java))
                     requireActivity().finish()
                 }
-                else -> {
-                    // TODO 에러케이스에 따라 에러메세지 분리 및 스낵바 커스텀 필요
+                false -> {
                     CustomSnackbar.make(binding.layout, getString(R.string.sign_in_failed_snackbar_text), false).show()
                 }
+                else -> {}
             }
         }
         viewModel.getSignProcessStatus().observe(viewLifecycleOwner) {


### PR DESCRIPTION
## What is this PR? 🔍
로그인 화면 진입하자마자 로그인 실패 스낵바가 뜨는 버그 수정
## Key Changes 🔑
1. 로그인 성공 여부 값이 false일 떄만 스낵바 보여주기
   - 기존에 true가 아닌 경우에 스낵바가 띄워졌던 것임
