### PR TITLE
[mod] 알림유형 데이터타입을 NotiType -> String으로 변경

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/data/model/noti/NotiItem.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/model/noti/NotiItem.kt
@@ -2,7 +2,7 @@ package com.hyeeyoung.wishboard.data.model.noti
 
 import com.google.gson.annotations.SerializedName
 import com.hyeeyoung.wishboard.domain.model.NotiItemInfo
-import com.hyeeyoung.wishboard.presentation.noti.types.NotiType
+import com.hyeeyoung.wishboard.util.extension.toNotiType
 
 data class NotiItem(
     @SerializedName("item_id")
@@ -17,7 +17,7 @@ data class NotiItem(
     @SerializedName("read_state")
     var readState: Int,
     @SerializedName("item_notification_type")
-    val notiType: NotiType,
+    val notiType: String,
     @SerializedName("item_notification_date")
     val notiDate: String,
 ) {
@@ -27,7 +27,7 @@ data class NotiItem(
         itemName,
         if (itemUrl.isNullOrBlank()) null else itemUrl,
         readState,
-        notiType,
+        notiType.toNotiType(),
         notiDate,
     )
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/data/model/wish/ItemDetail.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/model/wish/ItemDetail.kt
@@ -2,7 +2,7 @@ package com.hyeeyoung.wishboard.data.model.wish
 
 import com.google.gson.annotations.SerializedName
 import com.hyeeyoung.wishboard.domain.model.WishItemDetail
-import com.hyeeyoung.wishboard.presentation.noti.types.NotiType
+import com.hyeeyoung.wishboard.util.extension.toNotiType
 
 data class ItemDetail(
     @SerializedName("create_at")
@@ -22,7 +22,7 @@ data class ItemDetail(
     @SerializedName("item_notification_date")
     val notiDate: String?,
     @SerializedName("item_notification_type")
-    val notiType: NotiType?,
+    val notiType: String?,
     @SerializedName("item_price")
     val price: String,
     @SerializedName("item_url")
@@ -37,7 +37,7 @@ data class ItemDetail(
         if (memo.isNullOrBlank()) null else memo,
         name,
         notiDate,
-        notiType,
+        notiType?.toNotiType(),
         price,
         if (site.isNullOrBlank()) null else site
     )

--- a/app/src/main/java/com/hyeeyoung/wishboard/domain/repositories/WishRepository.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/domain/repositories/WishRepository.kt
@@ -33,7 +33,7 @@ interface WishRepository {
         itemImage: MultipartBody.Part?
     ): Pair<Boolean, Int>?
 
-    suspend fun updateFolderOfWishItem(folderId: Long, itemId: Long): Boolean
+    suspend fun updateFolderOfWishItem(itemId: Long, folderId: Long): Boolean
     suspend fun deleteWishItem(itemId: Long): Boolean
     suspend fun getItemParsingInfo(site: String): Pair<ItemInfo?, Int>?
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/screens/NotiSettingBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/screens/NotiSettingBottomDialogFragment.kt
@@ -6,12 +6,13 @@ import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.hyeeyoung.wishboard.databinding.DialogBottomNotiSettingBinding
-import com.hyeeyoung.wishboard.util.*
 import com.hyeeyoung.wishboard.presentation.wishitem.viewmodels.WishItemRegistrationViewModel
+import com.hyeeyoung.wishboard.util.*
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class NotiSettingBottomDialogFragment(private val viewModel: WishItemRegistrationViewModel) : BottomSheetDialogFragment() {
+class NotiSettingBottomDialogFragment(private val viewModel: WishItemRegistrationViewModel) :
+    BottomSheetDialogFragment() {
     private lateinit var binding: DialogBottomNotiSettingBinding
 
     override fun onCreateView(
@@ -51,9 +52,5 @@ class NotiSettingBottomDialogFragment(private val viewModel: WishItemRegistratio
         binding.back.setOnClickListener {
             dismiss()
         }
-    }
-
-    companion object {
-        const val TAG = "NotiSettingBottomDialogFragment"
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/types/NotiType.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/noti/types/NotiType.kt
@@ -1,11 +1,9 @@
 package com.hyeeyoung.wishboard.presentation.noti.types
 
-import com.hyeeyoung.wishboard.R
-
-enum class NotiType(val strRes: Int) {
-    RESTOCK(R.string.restock),
-    OPEN(R.string.open_day),
-    PREORDER(R.string.preorder),
-    SALE_START(R.string.sale_start),
-    SALE_CLOSE(R.string.sale_close)
+enum class NotiType(val str: String) {
+    RESTOCK("재입고"),
+    OPEN("오픈"),
+    PREORDER("프리오더"),
+    SALE_START("세일 시작"),
+    SALE_CLOSE("세일 마감")
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/wishitem/viewmodels/WishItemRegistrationViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/wishitem/viewmodels/WishItemRegistrationViewModel.kt
@@ -147,7 +147,7 @@ class WishItemRegistrationViewModel @Inject constructor(
                     itemPrice.value?.replace(",", "")?.toIntOrNull()?.toString()
                         ?.toPlainNullableRequestBody() // // TODO 가격 데이터에 천단위 구분자 ',' 있는 경우 문자열 처리 필요
                 val itemUrl: RequestBody = siteUrl.toPlainRequestBody()
-                val notiType: RequestBody? = notiType.value?.name?.toPlainNullableRequestBody()
+                val notiType: RequestBody? = notiType.value?.str?.toPlainNullableRequestBody()
                 val notiDate: RequestBody? = notiDate.value?.toPlainNullableRequestBody()
 
                 val imageMultipartBody: MultipartBody.Part? = itemImage.value?.let { imageUrl ->
@@ -201,7 +201,7 @@ class WishItemRegistrationViewModel @Inject constructor(
             ?.toPlainNullableRequestBody()
         val itemMemo: RequestBody? = getTrimmedMemo(itemMemo.value).toPlainNullableRequestBody()
         val itemUrl: RequestBody? = itemUrl.value.toPlainNullableRequestBody()
-        val notiType: RequestBody? = notiType.value?.name?.toPlainNullableRequestBody()
+        val notiType: RequestBody? = notiType.value?.str?.toPlainNullableRequestBody()
         val notiDate: RequestBody? = notiDate.value?.toPlainNullableRequestBody()
 
         val imageMultipartBody: MultipartBody.Part =
@@ -252,7 +252,7 @@ class WishItemRegistrationViewModel @Inject constructor(
             ?.toPlainNullableRequestBody()
         val itemMemo: RequestBody? = getTrimmedMemo(itemMemo.value).toPlainNullableRequestBody()
         val itemUrl: RequestBody? = itemUrl.value.toPlainNullableRequestBody()
-        val notiType: RequestBody? = notiType.value?.name?.toPlainNullableRequestBody()
+        val notiType: RequestBody? = notiType.value?.str?.toPlainNullableRequestBody()
         val notiDate: RequestBody? = notiDate.value?.toPlainNullableRequestBody()
 
         val imageMultipartBody: MultipartBody.Part? =
@@ -377,7 +377,8 @@ class WishItemRegistrationViewModel @Inject constructor(
             itemUrl.value = site
             itemUrlInput.value = site // 쇼핑몰 링크가 존재하는 아이템을 수정할 경우, 쇼핑몰 링크 EditText에 기존 링크를 보여주기 위함
             this@WishItemRegistrationViewModel.notiType.value = notiType
-            this@WishItemRegistrationViewModel.notiDate.value = notiDate
+            this@WishItemRegistrationViewModel.notiDate.value =
+                notiDate + ":00" // 초가 없으면 알림 수정 시 변경 사항 저장이 안됨.
         }
     }
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/NumberPickerUtil.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/NumberPickerUtil.kt
@@ -68,7 +68,7 @@ fun setTypePicker(typePicker: NumberPicker) {
         value = 0
         maxValue = notiTypes.size - 1
         displayedValues =
-            notiTypes.map { this.context.resources.getString(it.strRes) }.toTypedArray()
+            notiTypes.map { it.str }.toTypedArray()
         descendantFocusability = NumberPicker.FOCUS_BLOCK_DESCENDANTS
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/extension/StringExt.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/extension/StringExt.kt
@@ -1,5 +1,6 @@
 package com.hyeeyoung.wishboard.util.extension
 
+import com.hyeeyoung.wishboard.presentation.noti.types.NotiType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -9,3 +10,12 @@ fun String?.toPlainRequestBody(): RequestBody =
 
 fun String?.toPlainNullableRequestBody(): RequestBody? =
     this?.toRequestBody("text/plain".toMediaTypeOrNull())
+
+fun String.toNotiType() =
+    when (this) {
+        NotiType.RESTOCK.str -> NotiType.RESTOCK
+        NotiType.OPEN.str -> NotiType.OPEN
+        NotiType.PREORDER.str -> NotiType.PREORDER
+        NotiType.SALE_CLOSE.str -> NotiType.SALE_CLOSE
+        else -> NotiType.SALE_START
+    }

--- a/app/src/main/res/layout/activity_wish_link_sharing.xml
+++ b/app/src/main/res/layout/activity_wish_link_sharing.xml
@@ -111,7 +111,7 @@
                         android:layout_height="wrap_content"
                         android:fontFamily="@font/suit_r"
                         android:paddingVertical="@dimen/spacing10"
-                        android:text="@{viewModel.notiType == null ? context.getString(R.string.item_registration_noti_setting_title) : String.format(context.getString(R.string.item_notification_info_short), DateFormatUtilKt.convertKoreanDate(viewModel.notiDate), context.getString(viewModel.notiType.strRes))}"
+                        android:text="@{viewModel.notiType == null ? context.getString(R.string.item_registration_noti_setting_title) : String.format(context.getString(R.string.item_notification_info_short), DateFormatUtilKt.convertKoreanDate(viewModel.notiDate), viewModel.notiType.str)}"
                         android:textColor="@color/black"
                         android:textSize="@dimen/typographyDescription"
                         tools:text="22년 3월 8일 10시 재입고" />

--- a/app/src/main/res/layout/fragment_wish.xml
+++ b/app/src/main/res/layout/fragment_wish.xml
@@ -233,7 +233,7 @@
                             android:layout_height="wrap_content"
                             android:clickable="false"
                             android:hint="@string/item_schedule_notification"
-                            android:text="@{viewModel.notiType == null ? `` : String.format(context.getString(R.string.item_notification_info), context.getString(viewModel.notiType.strRes), DateFormatUtilKt.convertYMDHMToYMDAHM(viewModel.notiDate))}"
+                            android:text="@{viewModel.notiType == null ? `` : String.format(context.getString(R.string.item_notification_info), viewModel.notiType.str, DateFormatUtilKt.convertYMDHMToYMDAHM(viewModel.notiDate))}"
                             android:textAppearance="@style/Item.Basic.Upload.EditText.TextAppearance"
                             android:textColorHint="@color/gray_700"
                             app:layout_constraintBottom_toBottomOf="parent"

--- a/app/src/main/res/layout/fragment_wish_item_detail.xml
+++ b/app/src/main/res/layout/fragment_wish_item_detail.xml
@@ -106,7 +106,7 @@
                         android:fontFamily="@font/suit_sb"
                         android:paddingHorizontal="@dimen/spacingSmall"
                         android:paddingVertical="@dimen/spacingMicro"
-                        android:text="@{viewModel.itemDetail.notiType == null ? `` : context.getString(viewModel.itemDetail.notiType.strRes)}"
+                        android:text="@{viewModel.itemDetail.notiType == null ? `` : viewModel.itemDetail.notiType.str}"
                         android:textColor="@color/gray_700"
                         android:textSize="14sp"
                         android:visibility="@{viewModel.itemDetail.notiType == null ? View.INVISIBLE : View.VISIBLE}"

--- a/app/src/main/res/layout/item_calendar_noti.xml
+++ b/app/src/main/res/layout/item_calendar_noti.xml
@@ -45,7 +45,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing12"
             android:fontFamily="@font/suit_b"
-            android:text="@{@string/noti_item_type(context.getString(item.notiType.strRes))}"
+            android:text="@{@string/noti_item_type(item.notiType.str)}"
             android:textColor="@color/gray_700"
             android:textSize="14sp"
             app:layout_constraintStart_toEndOf="@id/item_image"

--- a/app/src/main/res/layout/item_noti.xml
+++ b/app/src/main/res/layout/item_noti.xml
@@ -51,7 +51,7 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="@dimen/spacing12"
             android:fontFamily="@font/suit_b"
-            android:text="@{String.format(context.getString(R.string.noti_item_type), context.getString(item.notiType.strRes))}"
+            android:text="@{String.format(context.getString(R.string.noti_item_type), item.notiType.str)}"
             android:textColor="@color/gray_700"
             android:textSize="14sp"
             app:layout_constraintStart_toEndOf="@id/item_image"


### PR DESCRIPTION
## What is this PR? 🔍
알림유형 데이터타입을 NotiType -> String으로 변경
알림유형을 enum 클래스에서 정의한 변수명으로 저장 -> 한글 String으로 저장하는 방식으로 변경하게 되었음

## Key Changes 🔑
1. 서버 통신 시 알림유형을 NotiType -> String으로 받도록 수정
   - data 레이어 모델을 domain 레이어 모델로 변환하는 과정에서 다시 String -> NotiType으로 변환하는 String 확장함수 toNotiType()추가
   - 기존에 NotiType을 사용하고 있는 파일들이 많아서 모두다 String으로 바꾸기에는 어려움이 있음. 또한 enum class로 상수값을 명확하게 갖고 있다면 분기처리 등 활용도가 좋기 때문에 서버 통신 시에만 잠깐 String으로 변환하기로 결정
