### PR TITLE
[fix] 릴리즈 모드에서 토큰 갱신 요청 시 크래시가 발생하는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/data/interceptor/AuthInterceptor.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/data/interceptor/AuthInterceptor.kt
@@ -31,6 +31,7 @@ class AuthInterceptor @Inject constructor(
 
         when (response.code) {
             401 -> {
+                response.close()
                 val requestBody = FormBody.Builder()
                     .add(REFRESH_TOKEN, localStorage.refreshToken).build()
 
@@ -50,6 +51,7 @@ class AuthInterceptor @Inject constructor(
                     responseRefresh.data?.token?.let {
                         localStorage.updateToken(it.accessToken, it.refreshToken)
                     }
+                    refreshTokenResponse.close()
 
                     val newRequest = originalRequest.newAuthBuilder().build()
                     return chain.proceed(newRequest)


### PR DESCRIPTION
## What is this PR? 🔍
릴리즈 모드에서 토큰 갱신 요청 시 새 request 생성 전에 이전 response를 close하지 않아 크래시가 발생하는 버그 수정

## Key Changes 🔑
1. 새 request 생성 전에 이전 response를 close()하는 코드 추가

