### PR TITLE
[fix] 디테일 뷰 > 폴더 선택 > 폴더 리스트가 보이지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderListAdapter.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderListAdapter.kt
@@ -213,9 +213,10 @@ class FolderListAdapter(
         notifyItemChanged(position)
     }
 
-    fun deleteData(folderItem: FolderItem) {
-        val position = dataSet.indexOf(folderItem)
-        dataSet.remove(folderItem)
+    fun deleteData(id: Long) {
+        val folder = dataSet.find { it.id ==  id }
+        val position = dataSet.indexOf(folder)
+        dataSet.remove(folder)
         notifyItemRemoved(position)
     }
 
@@ -224,7 +225,7 @@ class FolderListAdapter(
     }
 
     /** 링크 공유 전용 선택된 폴더 바꾸기 */
-    fun changeSelectedFolder(folder: FolderItem) {
+    private fun changeSelectedFolder(folder: FolderItem) {
         val unselectedFolder = selectedFolder
         selectedFolder = folder
         notifyItemChanged(dataSet.indexOf(unselectedFolder))

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderViewModel.kt
@@ -7,7 +7,6 @@ import androidx.lifecycle.viewModelScope
 import com.hyeeyoung.wishboard.data.model.folder.FolderItem
 import com.hyeeyoung.wishboard.domain.repositories.FolderRepository
 import com.hyeeyoung.wishboard.presentation.common.types.ProcessStatus
-import com.hyeeyoung.wishboard.presentation.folder.types.FolderListViewType
 import com.hyeeyoung.wishboard.util.UiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,28 +18,34 @@ import javax.inject.Inject
 class FolderViewModel @Inject constructor(
     private val folderRepository: FolderRepository,
 ) : ViewModel() {
-    private val _folderFetchState = MutableStateFlow<UiState<Boolean>>(UiState.Loading)
+    private val _folderFetchState = MutableStateFlow<UiState<List<FolderItem>>>(UiState.Init)
     val folderFetchState get() = _folderFetchState.asStateFlow()
-    private val folderList = MutableLiveData<List<FolderItem>?>(listOf())
-    private val folderListAdapter =
-        FolderListAdapter(FolderListViewType.VERTICAL_VIEW_TYPE)
-    private var folderName = MutableLiveData<String?>()
+    private val _folderDeleteState = MutableLiveData<UiState<Long>>(UiState.Init)
+    val folderDeleteState: LiveData<UiState<Long>> get() = _folderDeleteState
+    private val _folderAddState = MutableLiveData<UiState<FolderItem?>>(UiState.Init)
+    val folderAddState: LiveData<UiState<FolderItem?>> get() = _folderAddState
+    private val _folderUpdateState =
+        MutableLiveData<UiState<Pair<FolderItem, FolderItem>>>(UiState.Init)
+    val folderUpdateState: LiveData<UiState<Pair<FolderItem, FolderItem>>> get() = _folderUpdateState
+
+    private var folderName = MutableLiveData<String?>() // TODO val로 변경
     private var folderItem: FolderItem? = null
 
-    private var isCompleteUpload = MutableLiveData<Boolean?>()
-    private var isCompleteDeletion = MutableLiveData<Boolean>()
     private var isExistFolderName = MutableLiveData<Boolean?>()
     private var isEditMode: Boolean = false
 
     private var folderRegistrationStatus = MutableLiveData<ProcessStatus>()
+    private val _folderCount = MutableStateFlow(0)
+    val folderCount get() = _folderCount.asStateFlow()
 
     fun fetchFolderList() {
         viewModelScope.launch {
             folderRepository.fetchFolderList().let { folders ->
                 _folderFetchState.value =
-                    if (folders == null) UiState.Error(null) else UiState.Success(true)
-                folderList.value = folders
-                folderListAdapter.setData(folders)
+                    if (folders == null) UiState.Error(null)
+                    else if (folders.isEmpty()) UiState.Empty
+                    else UiState.Success(folders)
+                _folderCount.value = folders?.size ?: 0
             }
         }
     }
@@ -60,14 +65,18 @@ class FolderViewModel @Inject constructor(
         folderRegistrationStatus.value = ProcessStatus.IN_PROGRESS
         viewModelScope.launch {
             val result = folderRepository.createNewFolder(FolderItem(name = folderName))
-            isCompleteUpload.value = result?.first?.first
+            val isSuccessful = result?.first?.first
+            val folder = FolderItem(result?.second, folderName)
+            _folderAddState.value =
+                if (isSuccessful == true) {
+                    _folderCount.value += 1
+                    UiState.Success(folder)
+                } else {
+                    UiState.Error(null)
+                }
+
             isExistFolderName.value = result?.first?.second == 409
-            result?.second?.let { folderId ->
-                val folder = FolderItem(folderId, folderName)
-                folderListAdapter.addData(folder)
-                folderList.postValue(folderListAdapter.getData())
-            }
-            folderRegistrationStatus.postValue(ProcessStatus.IDLE)
+            folderRegistrationStatus.value = ProcessStatus.IDLE
         }
     }
 
@@ -81,24 +90,25 @@ class FolderViewModel @Inject constructor(
 
         viewModelScope.launch {
             val result = folderRepository.updateFolderName(oldFolder.id, folderName)
-            if (result?.first == true) {
-                folderListAdapter.updateData(oldFolder, newFolder)
-            }
-            isCompleteUpload.value = result?.first
+            val isSuccessful = result?.first
+            _folderUpdateState.value =
+                if (isSuccessful == true) UiState.Success(Pair(oldFolder, newFolder))
+                else UiState.Error(null)
             isExistFolderName.value = result?.second == 409
-            folderRegistrationStatus.postValue(ProcessStatus.IDLE)
+            folderRegistrationStatus.value = ProcessStatus.IDLE
         }
     }
 
     fun deleteFolder(folder: FolderItem?) {
         if (folder?.id == null) return
         viewModelScope.launch {
-            val result = folderRepository.deleteFolder(folder.id)
-            if (result) {
-                folderListAdapter.deleteData(folder)
-                folderList.value = folderListAdapter.getData()
+            val isSuccessful = folderRepository.deleteFolder(folder.id)
+            if (isSuccessful) {
+                _folderDeleteState.value = UiState.Success(folder.id)
+                _folderCount.value -= 1
+            } else {
+                _folderDeleteState.value = UiState.Error(null)
             }
-            isCompleteDeletion.postValue(result)
         }
     }
 
@@ -110,12 +120,13 @@ class FolderViewModel @Inject constructor(
     /** 폴더 추가 후 또 다른 폴더 추가/수정을 위해 이전에 입력한 폴더명 등의 폴더 관련 데이터를 reset */
     fun resetFolderData() {
         folderName.value = null
-        isCompleteUpload.value = null
+        if (isEditMode) _folderUpdateState.value = UiState.Init
+        else _folderAddState.value = UiState.Init
         isExistFolderName.value = null
     }
 
     fun resetCompleteDeletion() {
-        isCompleteDeletion.value = false
+        _folderDeleteState.value = UiState.Init
     }
 
     fun resetFolderName() {
@@ -131,11 +142,7 @@ class FolderViewModel @Inject constructor(
         isEditMode = isEditable
     }
 
-    fun getFolderList(): LiveData<List<FolderItem>?> = folderList
-    fun getFolderListAdapter(): FolderListAdapter = folderListAdapter
     fun getFolderName(): LiveData<String?> = folderName
-    fun getIsCompleteUpload(): LiveData<Boolean?> = isCompleteUpload
-    fun getIsCompleteDeletion(): LiveData<Boolean> = isCompleteDeletion
     fun getIsExistFolderName(): LiveData<Boolean?> = isExistFolderName
     fun getEditMode(): Boolean = isEditMode
     fun getRegistrationStatus(): LiveData<ProcessStatus> = folderRegistrationStatus

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderViewModel.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/FolderViewModel.kt
@@ -28,13 +28,13 @@ class FolderViewModel @Inject constructor(
         MutableLiveData<UiState<Pair<FolderItem, FolderItem>>>(UiState.Init)
     val folderUpdateState: LiveData<UiState<Pair<FolderItem, FolderItem>>> get() = _folderUpdateState
 
-    private var folderName = MutableLiveData<String?>() // TODO val로 변경
+    private val folderName = MutableLiveData<String?>()
     private var folderItem: FolderItem? = null
 
-    private var isExistFolderName = MutableLiveData<Boolean?>()
+    private val isExistFolderName = MutableLiveData<Boolean?>()
     private var isEditMode: Boolean = false
 
-    private var folderRegistrationStatus = MutableLiveData<ProcessStatus>()
+    private val folderRegistrationStatus = MutableLiveData<ProcessStatus>()
     private val _folderCount = MutableStateFlow(0)
     val folderCount get() = _folderCount.asStateFlow()
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/screens/FolderListBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/screens/FolderListBottomDialogFragment.kt
@@ -23,6 +23,11 @@ class FolderListBottomDialogFragment(private val folderId: Long?) :
     private val folderListAdapter =
         FolderListAdapter(FolderListViewType.HORIZONTAL_VIEW_TYPE)
 
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        viewModel.fetchFolderList()
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 

--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/screens/FolderListBottomDialogFragment.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/folder/screens/FolderListBottomDialogFragment.kt
@@ -11,6 +11,8 @@ import com.hyeeyoung.wishboard.presentation.folder.FolderListAdapter
 import com.hyeeyoung.wishboard.presentation.folder.FolderViewModel
 import com.hyeeyoung.wishboard.presentation.folder.types.FolderListViewType
 import com.hyeeyoung.wishboard.util.FolderListDialogListener
+import com.hyeeyoung.wishboard.util.UiState
+import com.hyeeyoung.wishboard.util.extension.collectFlow
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -55,11 +57,13 @@ class FolderListBottomDialogFragment(private val folderId: Long?) :
     }
 
     private fun addObservers() {
-        viewModel.getFolderList().observe(viewLifecycleOwner) {
-            it?.let {
-                if (it.isEmpty()) return@let
-                binding.noItemView.visibility = View.GONE
-                folderListAdapter.setData(it)
+        collectFlow(viewModel.folderFetchState) { fetchState ->
+            when (fetchState) {
+                is UiState.Success -> {
+                    binding.noItemView.visibility = View.GONE
+                    folderListAdapter.setData(items = fetchState.data)
+                }
+                else -> {}
             }
         }
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/UiState.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/UiState.kt
@@ -1,6 +1,7 @@
 package com.hyeeyoung.wishboard.util
 
 sealed class UiState<out T> {
+    object Init : UiState<Nothing>()
     object Loading : UiState<Nothing>()
     object Empty : UiState<Nothing>()
     data class Success<T>(val data: T) : UiState<T>()

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -49,7 +49,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/folder_no_item_view"
-            android:visibility="@{viewModel.folderList.size() > 0 ? View.GONE : View.VISIBLE}"
+            app:visibility="@{viewModel.folderCount &lt;= 0}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## What is this PR? 🔍
디테일 뷰 > 폴더 선택 > 폴더 리스트가 보이지 않는 버그 수정
## Key Changes 🔑
1. 디테일 뷰에서 폴더 선택 다이얼로그를 띄울 때 폴더 리스트가 보이지 않는 버그 수정
   - 기존에 FolderViewModel에서 init { } 블록에서 호출하던 폴더 리스트 조회 함수가 지워지면서 별도로 호출했어야하는 상황인데 호출을 하지 않고 있었음
2. 폴더 추가, 조회, 수정, 삭제 관련 코드 리팩토링
   - 기존에 FolderViewModel에서 FolderListAdapter 변수로 갖고 있었고, 어뎁터 내 함수들을 호출하고 있었음 -> Adatper를 Fragment 단으로 옮겨서 뷰에서 폴더 추가, 조회, 수정, 삭제 관련 Ui Update 처리를 하도록 수정
