### PR TITLE
[feat] 링크 공유 화면 상단바 투명화

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -22,6 +22,10 @@
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowAnimationStyle">@null</item>
         <item name="android:windowSoftInputMode">stateUnspecified|adjustPan</item>
+
+        <!-- Status bar color. -->
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 
     <style name="AppTheme.NumberPicker">


### PR DESCRIPTION
## What is this PR? 🔍
- closed #424

## Key Changes 🔑
1. 기존에 상태바가 다이얼로그 배경과 동떨어지는 화이트 색상이라 투명화를 적용함

|기존 화이트 상태바|변경 투명 상태바|
|---|---|
|<img width="230" alt="스크린샷 2023-07-25 오후 10 42 19" src="https://github.com/hyeeyoung/wishboard-android/assets/48701368/02fe1c77-f6e1-4602-8467-877763c3a73a">|<img width="222" alt="스크린샷 2023-07-25 오후 11 06 56" src="https://github.com/hyeeyoung/wishboard-android/assets/48701368/e3f1d364-467c-4d49-b2a8-9fd4577bb33f">|
