### PR TITLE
[del] WebViewActivity 종료 시 애니메이션을 제거하는 코드 삭제

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/presentation/common/screens/WebViewActivity.kt
+++ b/app/src/main/java/com/hyeeyoung/wishboard/presentation/common/screens/WebViewActivity.kt
@@ -42,11 +42,6 @@ class WebViewActivity : BaseActivity<ActivityWebviewBinding>(R.layout.activity_w
         }
     }
 
-    override fun onPause() {
-        super.onPause()
-        overridePendingTransition(0, 0)
-    }
-
     companion object {
         private const val ARG_WEB_VIEW_LINK = "link"
         private const val ARG_WEB_VIEW_TITLE = "title"


### PR DESCRIPTION
## What is this PR? 🔍
- closed #428

## Key Changes 🔑
1. 모든 액티비티와 마찬가지로 WebViewActivity도 종료 애니메이션을 보여주도록 통일
   - 기존에 WebViewActivity 종료 시 애니메이션을 제거하는 코드를 제거
